### PR TITLE
Decouples audience definitions from main edkt object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Using [unpkg](https://unpkg.com/):
 
 ```html
 <!--ES module-->
-<script type="module" src="https://unpkg.com/@airgrid/edgekit?module" crossorigin></script>
+<script
+  type="module"
+  src="https://unpkg.com/@airgrid/edgekit?module"
+  crossorigin
+></script>
 
 <!--UMD module-->
 <script src="https://unpkg.com/@airgrid/edgekit" crossorigin></script>
@@ -59,7 +63,10 @@ _Note: using the above URLs will always fetch the latest version, which could co
 
 ```html
 <!--UMD module-->
-<script src="https://unpkg.com/@airgrid/edgekit@0.0.0-dev.2/dist/edgekit.umd.js" crossorigin></script>
+<script
+  src="https://unpkg.com/@airgrid/edgekit@0.0.0-dev.2/dist/edgekit.umd.js"
+  crossorigin
+></script>
 ```
 
 ## Usage 🤓
@@ -77,7 +84,72 @@ EdgeKit will execute the following high level flow:
 
 #### Page Features
 
+A page feature is a list of keywords that describe a pages content.
+
+EdgeKit requires pageFeatureGetters to be passed into the run method that will allow EdgeKit to evaluate the page.
+
+```typescript
+const examplePageFeatureGetter = {
+   name: 'example',
+   func: (): Promise<string[]> => { ... }
+}
+```
+
+The following is a working example of a pageFeatureGetter that gets the meta data keywords from the head of the HTML.
+
+##### HTML
+
+```html
+<meta name="keywords" content="goal,liverpool,football,stadium" />
+```
+
+##### JS pageFeatureGetter
+
+```typescript
+const getHtmlKeywords = {
+  name: 'keywords',
+  func: (): Promise<string[]> => {
+    const tag = <HTMLElement>(
+      document.head.querySelector('meta[name="keywords"]')
+    );
+    const keywordString = tag.getAttribute('content') || '';
+    const keywords = keywordString.toLowerCase().split(',');
+    return Promise.resolve(keywords);
+  },
+};
+```
+
+##### JS EdgeKit Run
+
+```typescript
+import { edkt } from '../src';
+
+edkt.run({
+  pageFeatureGetters: [getHtmlKeywords],
+  audienceDefinitions: ...,
+});
+```
+
 #### Audience Evaluation
+
+In EdgeKit an audience refers to a group of users you would like to identify based on a list of keywords, the frequency of the user seeing one of the keywords and how long ago or recently they saw it.
+
+```typescript
+export const exampleAudience: AudienceDefinition = {
+  // Unique Identifier
+  id: '1234',
+  // Name of the Audience
+  name: 'Interest | typeOfIntrest',
+  // Time To Live - How long after matching the Audience are you part of it
+  ttl: TTL_IN_SECS,
+  // How long into the past should EdgeKit Look to match you to the audience
+  lookback: LOOKBACK_IN_SECS,
+  // Number of times the pageFeatureGetter must match a keyword to the keywords listed below
+  occurrences: OCCURRENCES,
+  // The Keywords used to identify the audience
+  keywords: listOfKeywords,
+};
+```
 
 #### Bidding Integration
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ EdgeKit will execute the following high level flow:
 
 A page feature is a list of keywords that describe a pages content.
 
-EdgeKit requires pageFeatureGetters to be passed into the run method that will allow EdgeKit to evaluate the page.
+EdgeKit requires pageFeatureGetters to be passed into the run method that will allow EdgeKit to evaluate the page. A pageFeatureGetter is an object that has a name and and an async function that resolves to a keyword list.
 
 ```typescript
 const examplePageFeatureGetter = {
@@ -122,7 +122,7 @@ const getHtmlKeywords = {
 ##### JS EdgeKit Run
 
 ```typescript
-import { edkt } from '../src';
+import { edkt } from '@airgrid/edgekit';
 
 edkt.run({
   pageFeatureGetters: [getHtmlKeywords],
@@ -149,6 +149,29 @@ export const exampleAudience: AudienceDefinition = {
   // The Keywords used to identify the audience
   keywords: listOfKeywords,
 };
+```
+
+EdgeKit comes with a range of audiences that you can use as examples or to get started straight away in your application.
+
+To use the the built in audiences you can import them from EdgeKit along with 'edkt'
+
+```typescript
+// use all built in audiences
+import { edkt, allAudienceDefinitions } from '@airgrid/edgekit';
+
+edkt.run({
+  pageFeatureGetters: [...],
+  audienceDefinitions: allAudienceDefinitions,
+});
+
+// use only the built in sport audience
+import { edkt, sportInterestAudience } from '@airgrid/edgekit';
+
+edkt.run({
+  pageFeatureGetters: [...],
+  audienceDefinitions: [sportInterestAudience],
+});
+
 ```
 
 #### Bidding Integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@airgrid/edgekit",
-  "version": "0.0.0-dev.0",
+  "version": "0.0.0-dev.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/audiences/index.ts
+++ b/src/audiences/index.ts
@@ -39,3 +39,10 @@ export const allAudienceDefinitions: AudienceDefinition[] = [
   travelInterestAudience,
   automotiveInterestAudience,
 ];
+
+export const audienceMap = {
+  all: allAudienceDefinitions,
+  sportInterestAudience,
+  travelInterestAudience,
+  automotiveInterestAudience,
+};

--- a/src/audiences/index.ts
+++ b/src/audiences/index.ts
@@ -39,10 +39,3 @@ export const allAudienceDefinitions: AudienceDefinition[] = [
   travelInterestAudience,
   automotiveInterestAudience,
 ];
-
-export const audienceMap = {
-  all: allAudienceDefinitions,
-  sportInterestAudience,
-  travelInterestAudience,
-  automotiveInterestAudience,
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,23 @@
 import * as engine from './engine';
-import { allAudienceDefinitions } from './audiences';
+import { audienceMap } from './audiences';
 import { getPageFeatures } from './features';
 import { viewStore, audienceStore } from './store';
 import { timeStampInSecs } from './utils';
-import { PageFeatureGetter, MatchedAudience } from 'types';
+import { PageFeatureGetter, MatchedAudience, AudienceDefinition } from 'types';
 
 interface Config {
   pageFeatureGetters: PageFeatureGetter[];
+  audienceDefinitions: AudienceDefinition[];
 }
 
 // TODO: we need to give a way to consumers to ensure this does not
 // run multiple times on a single page load.
 const run = async (config: Config): Promise<void> => {
-  const { pageFeatureGetters } = config;
+  const { pageFeatureGetters, audienceDefinitions } = config;
   const pageFeatures = await getPageFeatures(pageFeatureGetters);
   viewStore.insert(pageFeatures);
 
-  const matchedAudiences = allAudienceDefinitions
+  const matchedAudiences = audienceDefinitions
     .filter((audience) => {
       return !audienceStore.matchedAudienceIds.includes(audience.id);
     })
@@ -48,3 +49,5 @@ export const edkt = {
   run,
   getMatchedAudiences,
 };
+
+export const audienceDefinitions = audienceMap;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as engine from './engine';
-import { audienceMap } from './audiences';
 import { getPageFeatures } from './features';
 import { viewStore, audienceStore } from './store';
 import { timeStampInSecs } from './utils';
@@ -50,4 +49,4 @@ export const edkt = {
   getMatchedAudiences,
 };
 
-export const audienceDefinitions = audienceMap;
+export * from './audiences';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,4 +49,5 @@ export const edkt = {
   getMatchedAudiences,
 };
 
+// This will expose the exported audiences & allow tree shaking
 export * from './audiences';

--- a/test/edkt.test.ts
+++ b/test/edkt.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { edkt, audienceDefinitions } from '../src';
+import { edkt, allAudienceDefinitions } from '../src';
 
 const sportKeywordsString = 'golf,liverpool,football,stadium';
 // const travelKeywordsString = 'beach,holiday,cruise,mojito'
@@ -38,7 +38,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHtmlKeywords],
-      audienceDefinitions: audienceDefinitions.all,
+      audienceDefinitions: allAudienceDefinitions,
     });
 
     const edktPageViews = JSON.parse(
@@ -53,7 +53,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHttpKeywords],
-      audienceDefinitions: audienceDefinitions.all,
+      audienceDefinitions: allAudienceDefinitions,
     });
 
     const edktPageViews = JSON.parse(
@@ -83,7 +83,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHttpKeywords],
-      audienceDefinitions: audienceDefinitions.all,
+      audienceDefinitions: allAudienceDefinitions,
     });
 
     const edktMatchedAudiences = JSON.parse(

--- a/test/edkt.test.ts
+++ b/test/edkt.test.ts
@@ -63,6 +63,21 @@ describe('EdgeKit edkt() API tests', () => {
     expect(edktPageViews.length).toEqual(2);
   });
 
+  it('sports audience should not be stored in matched audiences when no audience definitions are sent', async () => {
+    fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
+
+    await edkt.run({
+      pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: [],
+    });
+
+    const edktMatchedAudiences = JSON.parse(
+      localStorage.getItem('edkt_matched_audiences') || '[]'
+    );
+
+    expect(edktMatchedAudiences.length).toEqual(0);
+  });
+
   it('sports audience should be stored in matched audiences', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 

--- a/test/edkt.test.ts
+++ b/test/edkt.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { edkt } from '../src';
+import { edkt, audienceDefinitions } from '../src';
 
 const sportKeywordsString = 'golf,liverpool,football,stadium';
 // const travelKeywordsString = 'beach,holiday,cruise,mojito'
@@ -38,6 +38,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHtmlKeywords],
+      audienceDefinitions: audienceDefinitions.all,
     });
 
     const edktPageViews = JSON.parse(
@@ -52,6 +53,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: audienceDefinitions.all,
     });
 
     const edktPageViews = JSON.parse(
@@ -66,6 +68,7 @@ describe('EdgeKit edkt() API tests', () => {
 
     await edkt.run({
       pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: audienceDefinitions.all,
     });
 
     const edktMatchedAudiences = JSON.parse(


### PR DESCRIPTION
closes https://github.com/AirGrid/edgekit/issues/16

This will expose the exported audiences from "./audiences" & allow tree shaking

examples of usage

```javascript 
import { edkt, allAudienceDefinitions } from '@airgrid/edgekit';

const edktConfig = {
  audienceDefinitions: audienceDefinitions.all,
  pageFeatureGetters,
};
```

or 

```javascript 
import { edkt, sportInterestAudience } from '@airgrid/edgekit';

const edktConfig = {
  audienceDefinitions: [sportInterestAudience],
  pageFeatureGetters,
};
```