### PR TITLE
Added initial code to check GDPR consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,22 @@ _Note: using the above URLs will always fetch the latest version, which could co
 
 EdgeKit will execute the following high level flow:
 
-1. **Register, run and store user defined `pageFeatureGetters`.**
+1. **Check for GDPR compliance.**
+   The IAB has an [API][iabapi] to check for GDPR compliance. Edgekit provides a simplified wrapper
+   around this API in order to check for compliance. A list of vendor ids is passed to the function.
+
+   You can find the list of vendors and their ids that are participating in the Transparency and
+   Consent Framework [here][vendorids].
+
+   Quoting the definition from [IAB policy site][iabpolicysite], a vendor is:
+
+   > “Vendor” means a company that participates in the delivery of digital advertising within a Publisher’s website, app, or other digital content, to the extent that company is not acting as a Publisher or CMP, and that either accesses an end user’s device or processes personal data about end users visiting the Publisher’s content and adheres to the Policies...
+
+2. **Register, run and store user defined `pageFeatureGetters`.**
    In this step the library will fetch `keywords` to describe the current page load, which will be stored locally to create a history of the pages viewed by the user visiting your site.
-2. **Run audience definitions against the local page views.**
+3. **Run audience definitions against the local page views.**
    The library now checks the users local history to see if they match any of the audience definitions, storing any matched audiences.
-3. **Make matched audiences available to bidding.**
+4. **Make matched audiences available to bidding.**
    The final step is to pass the newly defined audience signals to third party bidders, for example via Prebid.
 
 #### Page Features
@@ -122,12 +133,19 @@ const getHtmlKeywords = {
 ##### JS EdgeKit Run
 
 ```typescript
-import { edkt } from '@airgrid/edgekit';
+import { edkt, hasGdprConsent } from '@airgrid/edgekit';
 
+// Vendor ids to check for consent
+const vendorIds = [...]
+
+// Check for GDPR compliance for the provided vendor ids
+const hasConsent = await hasGdprConsent(vendorIds)
+
+// This function won't do anything unless `hasConsent` is `true`
 edkt.run({
   pageFeatureGetters: [getHtmlKeywords],
   audienceDefinitions: ...,
-});
+}, hasConsent);
 ```
 
 #### Audience Evaluation
@@ -205,3 +223,7 @@ See Contributing.
 ## Licence 💮
 
 MIT License | Copyright (c) 2020 AirGrid LTD | [Link](./LICENSE)
+
+[iabapi]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
+[iabpolicysite]: https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/
+[vendorids]: https://iabeurope.eu/vendor-list-tcf-v2-0/

--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ _Note: using the above URLs will always fetch the latest version, which could co
 EdgeKit will execute the following high level flow:
 
 1. **Check for GDPR compliance.**
-   The IAB has an [API][iabapi] to check for GDPR compliance. Edgekit provides a simplified wrapper
-   around this API in order to check for compliance. A list of vendor ids is passed to the function.
+   The IAB has an [API](https://cdn.edkt.io/sdk/edgekit.min.js) to check for GDPR compliance.
+   Edgekit provides a simplified wrapper around this API in order to check for compliance. A list of
+   vendor ids is passed to the function.
 
    You can find the list of vendors and their ids that are participating in the Transparency and
-   Consent Framework [here][vendorids].
+   Consent Framework [here](https://iabeurope.eu/vendor-list-tcf-v2-0/).
 
-   Quoting the definition from [IAB policy site][iabpolicysite], a vendor is:
+   Quoting the definition from [IAB policy site](https://cdn.edkt.io/sdk/edgekit.min.js), a vendor
+   is:
 
    > “Vendor” means a company that participates in the delivery of digital advertising within a Publisher’s website, app, or other digital content, to the extent that company is not acting as a Publisher or CMP, and that either accesses an end user’s device or processes personal data about end users visiting the Publisher’s content and adheres to the Policies...
 
@@ -133,19 +135,24 @@ const getHtmlKeywords = {
 ##### JS EdgeKit Run
 
 ```typescript
-import { edkt, hasGdprConsent } from '@airgrid/edgekit';
+import { edkt } from '@airgrid/edgekit';
 
-// Vendor ids to check for consent
-const vendorIds = [...]
-
-// Check for GDPR compliance for the provided vendor ids
-const hasConsent = await hasGdprConsent(vendorIds)
-
-// This function won't do anything unless `hasConsent` is `true`
+// If GDPR applies and consent has not been established then this function won't do anything
 edkt.run({
   pageFeatureGetters: [getHtmlKeywords],
   audienceDefinitions: ...,
-}, hasConsent);
+  vendorIds: ..., // vendor ids to check for consent
+});
+```
+
+Alternatively, pass in a flag to omit the GDPR check if it's not necessary for your use case:
+
+```typescript
+edkt.run({
+  pageFeatureGetters: [getHtmlKeywords],
+  audienceDefinitions: ...,
+  omitGdprConsent: true
+});
 ```
 
 #### Audience Evaluation
@@ -223,7 +230,3 @@ See Contributing.
 ## Licence 💮
 
 MIT License | Copyright (c) 2020 AirGrid LTD | [Link](./LICENSE)
-
-[iabapi]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
-[iabpolicysite]: https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/
-[vendorids]: https://iabeurope.eu/vendor-list-tcf-v2-0/

--- a/TCF-API-notes.md
+++ b/TCF-API-notes.md
@@ -1,0 +1,26 @@
+# Transparency and Consent Framework API Notes
+
+- [Full API
+  doc](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md)
+
+- The [vendor list](https://iabeurope.eu/vendor-list-tcf-v2-0/) (Airgrid is in there)
+
+- API implementors should provide a [stub
+  script](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-does-the-cmp-stub-api-work)
+  initiailly before any other scripts that depend on it are loaded. This builds up a queue of
+  callbacks until the CMF is loaded.
+
+- Scripts that rely on the API (ie. Edgekit) [shouldn't need to check if it's
+  loaded](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-can-scripts-determine-if-the-cmp-script-is-loaded-yet),
+  the API implementor should build up a queue of the callbacks with the stub script and then execute
+  them once fully loaded.
+
+- [In order to determine if a CMP is
+  present](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-can-scripts-on-a-page-determine-if-there-is-a-cmp-present), scripts can check for the presence of a function named `__tcfapi` – if it exists then a CMP can be assumed to be present for scripts.
+
+- According to the API spec
+  [here](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-does-the-gdprapplies-value-mean),
+  `gdprApplies` can also exist as an entry in the result and be `undefined`, which means that it is
+  yet to be determined. However, for the `getTCData` request, the API spec [also
+  specifies](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata)
+  that the callback should not be invoked until `gdprApplies` is known.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bundle": "microbundle --format umd,esm --name edkt",
     "watch": "tsc -w",
     "test": "jest --verbose",
+    "test:watch": "jest --watch --verbose",
     "test:coverage": "jest --coverage",
     "lint": "eslint src test --ext js,ts",
     "lint:fix": "lint --fix"

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -13,7 +13,7 @@ interface PingResponse {
   gdprApplies?: boolean;
 }
 
-interface TCData {
+export interface TCData {
   gdprApplies?: boolean;
   vendor: {
     consents: { [vendorId: number]: boolean | undefined };

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -1,50 +1,10 @@
-/*
-Full API doc
-https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
+import { TCData } from '../../types';
 
-How can scripts on a page determine if there is a CMP present?
-https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-can-scripts-on-a-page-determine-if-there-is-a-cmp-present
-
-Ping
-https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#ping
-*/
-
-interface PingResponse {
-  gdprApplies?: boolean;
-}
-
-export interface TCData {
-  gdprApplies?: boolean;
-  vendor: {
-    consents: { [vendorId: number]: boolean | undefined };
-  };
-}
-
-declare global {
-  interface Window {
-    __tcfapi(
-      command: 'ping',
-      version: number,
-      cb: (response: PingResponse) => void
-    ): void;
-
-    __tcfapi(
-      command: 'getTCData',
-      version: number,
-      cb: (tcData: TCData, success: boolean) => void
-    ): void;
-  }
-}
-
-/*
-Note: the api assumes that `undefined` is a still pending response, so hasGdprConsent would be false
-https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-does-the-gdprapplies-value-mean
-*/
 const hasConsent = (gdprApplies?: boolean): boolean => {
   return gdprApplies === undefined ? false : gdprApplies;
 };
 
-export const hasGdprConsent = (vendorIds: number[]): Promise<boolean> => {
+export const hasGdprConsent = (vendorIds?: number[]): Promise<boolean> => {
   return new Promise((resolve) => {
     // If the api is missing then assume no consent
     if (window.__tcfapi === undefined) resolve(false);
@@ -53,13 +13,13 @@ export const hasGdprConsent = (vendorIds: number[]): Promise<boolean> => {
         'getTCData',
         2,
         ({ gdprApplies, vendor }: TCData, success: boolean) => {
-          if (!success) {
-            resolve(false);
-          } else {
+          if (success && vendorIds) {
             resolve(
               hasConsent(gdprApplies) &&
                 vendorIds.every((vendorId) => !!vendor.consents[vendorId])
             );
+          } else {
+            resolve(false);
           }
         }
       );

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -1,0 +1,68 @@
+/*
+Full API doc
+https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
+
+How can scripts on a page determine if there is a CMP present?
+https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-can-scripts-on-a-page-determine-if-there-is-a-cmp-present
+
+Ping
+https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#ping
+*/
+
+interface PingResponse {
+  gdprApplies?: boolean;
+}
+
+interface TCData {
+  gdprApplies?: boolean;
+  vendor: {
+    consents: { [vendorId: number]: boolean | undefined };
+  };
+}
+
+declare global {
+  interface Window {
+    __tcfapi(
+      command: 'ping',
+      version: number,
+      cb: (response: PingResponse) => void
+    ): void;
+
+    __tcfapi(
+      command: 'getTCData',
+      version: number,
+      cb: (tcData: TCData, success: boolean) => void
+    ): void;
+  }
+}
+
+/*
+Note: the api assumes that `undefined` is a still pending response, so hasGdprConsent would be false
+https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-does-the-gdprapplies-value-mean
+*/
+const hasConsent = (gdprApplies?: boolean): boolean => {
+  return gdprApplies === undefined ? false : gdprApplies;
+};
+
+export const hasGdprConsent = (vendorIds: number[]): Promise<boolean> => {
+  return new Promise((resolve) => {
+    // If the api is missing then assume no consent
+    if (window.__tcfapi === undefined) resolve(false);
+    else {
+      window.__tcfapi(
+        'getTCData',
+        2,
+        ({ gdprApplies, vendor }: TCData, success: boolean) => {
+          if (!success) {
+            resolve(false);
+          } else {
+            resolve(
+              hasConsent(gdprApplies) &&
+                vendorIds.every((vendorId) => !!vendor.consents[vendorId])
+            );
+          }
+        }
+      );
+    }
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ interface Config {
 
 // TODO: we need to give a way to consumers to ensure this does not
 // run multiple times on a single page load.
-const run = async (config: Config): Promise<void> => {
+const run = async (config: Config, hasGdprConsent?: boolean): Promise<void> => {
+  if (!hasGdprConsent) return;
   const { pageFeatureGetters, audienceDefinitions } = config;
   const pageFeatures = await getPageFeatures(pageFeatureGetters);
   viewStore.insert(pageFeatures);
@@ -62,4 +63,5 @@ export const edkt = {
 // This will expose the exported audiences & allow tree shaking
 export * from './audiences';
 export * from './store';
+export * from './gdpr';
 export * from '../types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as engine from './engine';
 import { getPageFeatures } from './features';
 import { viewStore, matchedAudienceStore } from './store';
 import { timeStampInSecs } from './utils';
+import { hasGdprConsent } from './gdpr';
 import {
   PageFeatureGetter,
   MatchedAudience,
@@ -11,12 +12,18 @@ import {
 interface Config {
   pageFeatureGetters: PageFeatureGetter[];
   audienceDefinitions: AudienceDefinition[];
+  vendorIds?: number[];
+  omitGdprConsent?: boolean;
 }
 
 // TODO: we need to give a way to consumers to ensure this does not
 // run multiple times on a single page load.
-const run = async (config: Config, hasGdprConsent?: boolean): Promise<void> => {
-  if (!hasGdprConsent) return;
+const run = async (config: Config): Promise<void> => {
+  if (config.omitGdprConsent !== true) {
+    const hasConsent = await hasGdprConsent(config.vendorIds);
+    if (!hasConsent) return;
+  }
+
   const { pageFeatureGetters, audienceDefinitions } = config;
   const pageFeatures = await getPageFeatures(pageFeatureGetters);
   viewStore.insert(pageFeatures);

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -12,17 +12,23 @@ describe('Test edkt audience matching', () => {
   beforeAll(async () => {
     localStorage.clear();
     // add one initial view
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportInterestAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportInterestAudience],
+      },
+      true
+    );
   });
 
   it('First run -> add page view but do not match', async () => {
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportInterestAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportInterestAudience],
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -37,10 +43,13 @@ describe('Test edkt audience matching', () => {
   });
 
   it('Second run -> add another page view & match', async () => {
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportInterestAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportInterestAudience],
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -55,10 +64,13 @@ describe('Test edkt audience matching', () => {
   });
 
   it('Third run -> add another page view & match', async () => {
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportInterestAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportInterestAudience],
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -12,23 +12,19 @@ describe('Test edkt audience matching', () => {
   beforeAll(async () => {
     localStorage.clear();
     // add one initial view
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportInterestAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportInterestAudience],
+      omitGdprConsent: true,
+    });
   });
 
   it('First run -> add page view but do not match', async () => {
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportInterestAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportInterestAudience],
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -43,13 +39,11 @@ describe('Test edkt audience matching', () => {
   });
 
   it('Second run -> add another page view & match', async () => {
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportInterestAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportInterestAudience],
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -64,13 +58,11 @@ describe('Test edkt audience matching', () => {
   });
 
   it('Third run -> add another page view & match', async () => {
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportInterestAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportInterestAudience],
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'

--- a/test/edkt.test.ts
+++ b/test/edkt.test.ts
@@ -36,10 +36,13 @@ describe('EdgeKit edkt() API tests', () => {
   it('expects edkt_page_views length to be 1', async () => {
     document.head.innerHTML = sportsKeywordsHtml;
 
-    await edkt.run({
-      pageFeatureGetters: [getHtmlKeywords],
-      audienceDefinitions: allAudienceDefinitions,
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [getHtmlKeywords],
+        audienceDefinitions: allAudienceDefinitions,
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -51,10 +54,13 @@ describe('EdgeKit edkt() API tests', () => {
   it('expects edkt_page_views length to be 2', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run({
-      pageFeatureGetters: [getHttpKeywords],
-      audienceDefinitions: allAudienceDefinitions,
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [getHttpKeywords],
+        audienceDefinitions: allAudienceDefinitions,
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -66,10 +72,13 @@ describe('EdgeKit edkt() API tests', () => {
   it('sports audience should not be stored in matched audiences when no audience definitions are sent', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run({
-      pageFeatureGetters: [getHttpKeywords],
-      audienceDefinitions: [],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [getHttpKeywords],
+        audienceDefinitions: [],
+      },
+      true
+    );
 
     const edktMatchedAudiences = JSON.parse(
       localStorage.getItem('edkt_matched_audiences') || '[]'
@@ -81,10 +90,13 @@ describe('EdgeKit edkt() API tests', () => {
   it('sports audience should be stored in matched audiences', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run({
-      pageFeatureGetters: [getHttpKeywords],
-      audienceDefinitions: allAudienceDefinitions,
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [getHttpKeywords],
+        audienceDefinitions: allAudienceDefinitions,
+      },
+      true
+    );
 
     const edktMatchedAudiences = JSON.parse(
       localStorage.getItem('edkt_matched_audiences') || '[]'

--- a/test/edkt.test.ts
+++ b/test/edkt.test.ts
@@ -36,13 +36,11 @@ describe('EdgeKit edkt() API tests', () => {
   it('expects edkt_page_views length to be 1', async () => {
     document.head.innerHTML = sportsKeywordsHtml;
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [getHtmlKeywords],
-        audienceDefinitions: allAudienceDefinitions,
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [getHtmlKeywords],
+      audienceDefinitions: allAudienceDefinitions,
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -54,13 +52,11 @@ describe('EdgeKit edkt() API tests', () => {
   it('expects edkt_page_views length to be 2', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [getHttpKeywords],
-        audienceDefinitions: allAudienceDefinitions,
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: allAudienceDefinitions,
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -72,13 +68,11 @@ describe('EdgeKit edkt() API tests', () => {
   it('sports audience should not be stored in matched audiences when no audience definitions are sent', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [getHttpKeywords],
-        audienceDefinitions: [],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: [],
+      omitGdprConsent: true,
+    });
 
     const edktMatchedAudiences = JSON.parse(
       localStorage.getItem('edkt_matched_audiences') || '[]'
@@ -90,13 +84,11 @@ describe('EdgeKit edkt() API tests', () => {
   it('sports audience should be stored in matched audiences', async () => {
     fetchMock.mockOnce(JSON.stringify(sportKeywordsString));
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [getHttpKeywords],
-        audienceDefinitions: allAudienceDefinitions,
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [getHttpKeywords],
+      audienceDefinitions: allAudienceDefinitions,
+      omitGdprConsent: true,
+    });
 
     const edktMatchedAudiences = JSON.parse(
       localStorage.getItem('edkt_matched_audiences') || '[]'

--- a/test/gdpr.test.ts
+++ b/test/gdpr.test.ts
@@ -1,0 +1,144 @@
+import { edkt, hasGdprConsent } from '../src';
+import { TCData } from '../src/gdpr';
+import { AudienceDefinition } from '../types';
+// import { viewStore, matchedAudienceStore } from '../src/store';
+
+declare global {
+  interface Window {
+    __tcfapi(
+      command: 'getTCData',
+      version: number,
+      cb: (tcData: TCData, success: boolean) => void
+    ): void;
+  }
+}
+
+const TTL = 10;
+const airgridVendorId = 782;
+let consents = { [airgridVendorId]: false };
+let gdprApplies: boolean | undefined;
+
+const injectTcfApi = () => {
+  window.__tcfapi = (
+    command: string,
+    _: number,
+    cb: (tcData: TCData, success: boolean) => void
+  ) => {
+    if (command === 'getTCData') {
+      cb({ gdprApplies, vendor: { consents: consents } }, true);
+    }
+  };
+};
+
+const sportAudience: AudienceDefinition = {
+  id: 'sport_id',
+  name: 'Sport Audience',
+  ttl: TTL,
+  lookBack: 10,
+  occurrences: 0,
+  keywords: ['sport'],
+  version: 1,
+};
+
+/*
+const setUpLocalStorage = (pageViews: Array<PageView>) => {
+  localStorage.clear();
+  localStorage.setItem('edkt_page_views', JSON.stringify(pageViews));
+  //We need to reload from local storage because its only done on construction
+  viewStore._load();
+  matchedAudienceStore._load();
+};
+*/
+
+const sportPageFeatureGetter = {
+  name: 'keywords',
+  func: (): Promise<string[]> => {
+    return Promise.resolve(['sport']);
+  },
+};
+
+describe.only('EdgeKit GDPR tests', () => {
+  it('should fail to consent if the Transparency and Consent Framework API is missing', async () => {
+    expect(window.__tcfapi).toBeUndefined();
+    const hasConsent = await hasGdprConsent([airgridVendorId]);
+    expect(hasConsent).toBe(false);
+  });
+
+  it('should fail to consent if the api is there but gdprApplies is undefined or false', async () => {
+    injectTcfApi();
+
+    expect(window.__tcfapi).not.toBeUndefined();
+    expect(await hasGdprConsent([airgridVendorId])).toBe(false);
+
+    gdprApplies = false;
+    expect(await hasGdprConsent([airgridVendorId])).toBe(false);
+  });
+
+  it(`should not consent if GDPR applies but the vendor does't consent`, async () => {
+    gdprApplies = true;
+    expect(consents[airgridVendorId]).toBe(false);
+    expect(await hasGdprConsent([airgridVendorId])).toBe(false);
+  });
+
+  it('should consent if GDPR applies and the vender consents', async () => {
+    consents = { [airgridVendorId]: true };
+    expect(window.__tcfapi).not.toBeUndefined();
+    expect(await hasGdprConsent([airgridVendorId])).toBe(true);
+  });
+
+  it('should not run edgekit if there is no GDPR consent', async () => {
+    const hasConsent = false;
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportAudience],
+      },
+      hasConsent
+    );
+
+    const edktPageViews = JSON.parse(
+      localStorage.getItem('edkt_page_views') || '[]'
+    );
+
+    const edktMatchedAudiences = JSON.parse(
+      localStorage.getItem('edkt_matched_audiences') || '[]'
+    );
+
+    expect(edktPageViews).toHaveLength(0);
+    expect(edktMatchedAudiences).toHaveLength(0);
+  });
+
+  it('should run edgekit if there is GDPR consent', async () => {
+    const hasConsent = await hasGdprConsent([airgridVendorId]);
+    expect(hasConsent).toBe(true);
+
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportAudience],
+      },
+      hasConsent
+    );
+
+    const edktPageViews = JSON.parse(
+      localStorage.getItem('edkt_page_views') || '[]'
+    );
+
+    const edktMatchedAudiences = JSON.parse(
+      localStorage.getItem('edkt_matched_audiences') || '[]'
+    );
+
+    expect(edktPageViews).toEqual([
+      { features: { keywords: ['sport'] }, ts: edktPageViews[0].ts },
+    ]);
+
+    expect(edktMatchedAudiences).toEqual([
+      {
+        id: 'sport_id',
+        matched: true,
+        matchedOnCurrentPageView: true,
+        ...edktMatchedAudiences[0],
+      },
+    ]);
+  });
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -86,13 +86,11 @@ describe('Test basic edkt run', () => {
   it('does not match with one sport page view', async () => {
     setUpLocalStorage(ONE_SPORTS_PAGE_VIEW);
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportAudience],
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -112,13 +110,11 @@ describe('Test basic edkt run', () => {
   it('does match with two sport page view', async () => {
     setUpLocalStorage(TWO_SPORTS_PAGE_VIEW);
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [sportPageFeatureGetter],
-        audienceDefinitions: [sportAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [sportPageFeatureGetter],
+      audienceDefinitions: [sportAudience],
+      omitGdprConsent: true,
+    });
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -140,13 +136,11 @@ describe('Test look back edkt run', () => {
   it('does match with lookBack set to 0 with two demo page view at any point in the past', async () => {
     setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [lookBackPageFeatureGetter],
-        audienceDefinitions: [lookBackInfinityAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [lookBackPageFeatureGetter],
+      audienceDefinitions: [lookBackInfinityAudience],
+      omitGdprConsent: true,
+    });
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(1);
@@ -156,13 +150,11 @@ describe('Test look back edkt run', () => {
   it('does match with lookBack set to 2 with two blank page view within look back period', async () => {
     setUpLocalStorage(LOOK_BACK_PAGE_VIEW);
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [lookBackPageFeatureGetter],
-        audienceDefinitions: [lookBackAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [lookBackPageFeatureGetter],
+      audienceDefinitions: [lookBackAudience],
+      omitGdprConsent: true,
+    });
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(1);
@@ -172,13 +164,11 @@ describe('Test look back edkt run', () => {
   it('does not match with lookBack set to 2 with two blank page view outside look back period', async () => {
     setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
 
-    await edkt.run(
-      {
-        pageFeatureGetters: [lookBackPageFeatureGetter],
-        audienceDefinitions: [lookBackAudience],
-      },
-      true
-    );
+    await edkt.run({
+      pageFeatureGetters: [lookBackPageFeatureGetter],
+      audienceDefinitions: [lookBackAudience],
+      omitGdprConsent: true,
+    });
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(0);

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -86,10 +86,13 @@ describe('Test basic edkt run', () => {
   it('does not match with one sport page view', async () => {
     setUpLocalStorage(ONE_SPORTS_PAGE_VIEW);
 
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportAudience],
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -109,10 +112,13 @@ describe('Test basic edkt run', () => {
   it('does match with two sport page view', async () => {
     setUpLocalStorage(TWO_SPORTS_PAGE_VIEW);
 
-    await edkt.run({
-      pageFeatureGetters: [sportPageFeatureGetter],
-      audienceDefinitions: [sportAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [sportPageFeatureGetter],
+        audienceDefinitions: [sportAudience],
+      },
+      true
+    );
 
     const edktPageViews = JSON.parse(
       localStorage.getItem('edkt_page_views') || '[]'
@@ -134,10 +140,13 @@ describe('Test look back edkt run', () => {
   it('does match with lookBack set to 0 with two demo page view at any point in the past', async () => {
     setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
 
-    await edkt.run({
-      pageFeatureGetters: [lookBackPageFeatureGetter],
-      audienceDefinitions: [lookBackInfinityAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [lookBackPageFeatureGetter],
+        audienceDefinitions: [lookBackInfinityAudience],
+      },
+      true
+    );
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(1);
@@ -147,10 +156,13 @@ describe('Test look back edkt run', () => {
   it('does match with lookBack set to 2 with two blank page view within look back period', async () => {
     setUpLocalStorage(LOOK_BACK_PAGE_VIEW);
 
-    await edkt.run({
-      pageFeatureGetters: [lookBackPageFeatureGetter],
-      audienceDefinitions: [lookBackAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [lookBackPageFeatureGetter],
+        audienceDefinitions: [lookBackAudience],
+      },
+      true
+    );
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(1);
@@ -160,10 +172,13 @@ describe('Test look back edkt run', () => {
   it('does not match with lookBack set to 2 with two blank page view outside look back period', async () => {
     setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
 
-    await edkt.run({
-      pageFeatureGetters: [lookBackPageFeatureGetter],
-      audienceDefinitions: [lookBackAudience],
-    });
+    await edkt.run(
+      {
+        pageFeatureGetters: [lookBackPageFeatureGetter],
+        audienceDefinitions: [lookBackAudience],
+      },
+      true
+    );
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();
     expect(edktMatchedAudiences.length).toEqual(0);

--- a/types/index.ts
+++ b/types/index.ts
@@ -86,3 +86,30 @@ export interface EngineCondition {
   };
   rules: EngineConditionRule[];
 }
+
+export interface PingResponse {
+  gdprApplies?: boolean;
+}
+
+export interface TCData {
+  gdprApplies?: boolean;
+  vendor: {
+    consents: { [vendorId: number]: boolean | undefined };
+  };
+}
+
+declare global {
+  interface Window {
+    __tcfapi(
+      command: 'ping',
+      version: number,
+      cb: (response: PingResponse) => void
+    ): void;
+
+    __tcfapi(
+      command: 'getTCData',
+      version: number,
+      cb: (tcData: TCData, success: boolean) => void
+    ): void;
+  }
+}


### PR DESCRIPTION
closes #34 

I'm not sure if it's missing some necessary data from [here](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata)

For example I'm not sure if it needs to do anything with `outOfBand.allowedVendors`, `purpose.consents`, `publisher.consents`, `publisher.customPurpose.consents` and `publisher.restrictions`. Right now it's just checking if `gdprApplies` and if `vendor.consent` is true for all passed in vendors.

I tried to read through the docs but I haven't fully grokked it yet. I found some definitions for the various legal terms [here](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/)