### PR TITLE
Added setPageFeatures method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { viewStore, matchedAudienceStore } from './store';
 import { timeStampInSecs } from './utils';
 import { waitForConsent, runOnConsent } from './gdpr';
 import {
+  PageFeature,
   PageFeatureGetter,
   PageFeatureResult,
   MatchedAudience,
@@ -17,6 +18,8 @@ interface Config {
   vendorIds?: number[];
   omitGdprConsent?: boolean;
 }
+
+let savedPageFeatures: PageFeature[] = [];
 
 const setPageFeatures = async (
   vendorIds: number[],
@@ -36,7 +39,7 @@ const setPageFeatures = async (
       error: false,
     })
   );
-  viewStore.insert(pageFeatures);
+  savedPageFeatures = savedPageFeatures.concat(pageFeatures);
 };
 
 const run = async (config: Config): Promise<void> => {
@@ -47,7 +50,7 @@ const run = async (config: Config): Promise<void> => {
 
   const { pageFeatureGetters, audienceDefinitions } = config;
   const pageFeatures = await getPageFeatures(pageFeatureGetters);
-  viewStore.insert(pageFeatures);
+  viewStore.insert(savedPageFeatures.concat(pageFeatures));
 
   const matchedAudiences = audienceDefinitions
     .filter((audience) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as engine from './engine';
 import { getPageFeatures } from './features';
 import { viewStore, matchedAudienceStore } from './store';
 import { timeStampInSecs } from './utils';
-import { waitForConsent, runOnConsent } from './gdpr';
+import { waitForConsent } from './gdpr';
 import {
   PageFeature,
   PageFeatureGetter,
@@ -21,17 +21,8 @@ interface Config {
 
 let savedPageFeatures: PageFeature[] = [];
 
-const setPageFeatures = async (
-  vendorIds: number[],
-  features: Record<string, PageFeatureResult>,
-  omitGdprConsent = false
-): Promise<void> => {
-  const featuresResponse = await runOnConsent(
-    vendorIds,
-    async () => features,
-    omitGdprConsent
-  );
-  const pageFeatures = Object.entries(featuresResponse).map(
+const setPageFeatures = (features: Record<string, PageFeatureResult>): void => {
+  const pageFeatures = Object.entries(features).map(
     ([name, { version, value }]) => ({
       name,
       value,

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,6 +1,6 @@
 import { PageFeatureResult } from '../types';
 import { getPageFeatures } from '../src/features';
-import { viewStore } from 'src/store';
+import { viewStore } from '../src/store';
 import { edkt } from '../src';
 
 describe('EdgeKit | Features Module', () => {
@@ -37,6 +37,7 @@ describe('EdgeKit | Features Module', () => {
   });
 
   describe('setPageFeature', () => {
+    const vendorIds = [873];
     const omitGdprConsent = true;
 
     const features = {
@@ -66,7 +67,14 @@ describe('EdgeKit | Features Module', () => {
     });
 
     it('should set the page features in the store', async () => {
-      await edkt.setPageFeatures([873], features, omitGdprConsent);
+      await edkt.setPageFeatures(vendorIds, features, omitGdprConsent);
+      await edkt.setPageFeatures(vendorIds, moreFeatures, omitGdprConsent);
+
+      await edkt.run({
+        pageFeatureGetters: [],
+        audienceDefinitions: [],
+        omitGdprConsent,
+      });
 
       const edktPageViews = JSON.parse(
         localStorage.getItem('edkt_page_views') || '[]'
@@ -74,27 +82,11 @@ describe('EdgeKit | Features Module', () => {
 
       expect(edktPageViews).toEqual([
         {
-          features,
+          features: {
+            ...features,
+            ...moreFeatures,
+          },
           ts: edktPageViews[0].ts,
-        },
-      ]);
-    });
-
-    it('should set additional page features in the store', async () => {
-      await edkt.setPageFeatures([873], moreFeatures, omitGdprConsent);
-
-      const edktPageViews = JSON.parse(
-        localStorage.getItem('edkt_page_views') || '[]'
-      );
-
-      expect(edktPageViews).toEqual([
-        {
-          features,
-          ts: edktPageViews[0].ts,
-        },
-        {
-          features: moreFeatures,
-          ts: edktPageViews[1].ts,
         },
       ]);
     });

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -67,13 +67,14 @@ describe('EdgeKit | Features Module', () => {
     });
 
     it('should set the page features in the store', async () => {
-      await edkt.setPageFeatures(vendorIds, features, omitGdprConsent);
-      await edkt.setPageFeatures(vendorIds, moreFeatures, omitGdprConsent);
+      edkt.setPageFeatures(features);
+      edkt.setPageFeatures(moreFeatures);
 
       await edkt.run({
         pageFeatureGetters: [],
         audienceDefinitions: [],
         omitGdprConsent,
+        vendorIds,
       });
 
       const edktPageViews = JSON.parse(

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,5 +1,7 @@
 import { PageFeatureResult } from '../types';
 import { getPageFeatures } from '../src/features';
+import { viewStore } from 'src/store';
+import { edkt } from '../src';
 
 describe('EdgeKit | Features Module', () => {
   it('able to extract html keywords', async () => {
@@ -31,6 +33,70 @@ describe('EdgeKit | Features Module', () => {
       name: 'keywords',
       version: 1,
       value: ['sport', 'news', 'football', 'stadium'],
+    });
+  });
+
+  describe('setPageFeature', () => {
+    const omitGdprConsent = true;
+
+    const features = {
+      keywords: {
+        version: 1,
+        value: ['sport', 'soccer', 'football'],
+      },
+      someVector: {
+        version: 2,
+        value: [0.4, 0.2, 0.1, 0.8],
+      },
+    };
+
+    const moreFeatures = {
+      metaKeywords: {
+        version: 1,
+        value: ['foo', 'bar', 'baz'],
+      },
+    };
+
+    beforeAll(() => {
+      viewStore._load();
+    });
+
+    afterAll(() => {
+      localStorage.clear();
+    });
+
+    it('should set the page features in the store', async () => {
+      await edkt.setPageFeatures([873], features, omitGdprConsent);
+
+      const edktPageViews = JSON.parse(
+        localStorage.getItem('edkt_page_views') || '[]'
+      );
+
+      expect(edktPageViews).toEqual([
+        {
+          features,
+          ts: edktPageViews[0].ts,
+        },
+      ]);
+    });
+
+    it('should set additional page features in the store', async () => {
+      await edkt.setPageFeatures([873], moreFeatures, omitGdprConsent);
+
+      const edktPageViews = JSON.parse(
+        localStorage.getItem('edkt_page_views') || '[]'
+      );
+
+      expect(edktPageViews).toEqual([
+        {
+          features,
+          ts: edktPageViews[0].ts,
+        },
+        {
+          features: moreFeatures,
+          ts: edktPageViews[1].ts,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
# Summary

Adds a setPageFeatures method to set page features

Related to #57 and airgrid/rmap#351

## Details

Adds a setPageFeatures method in order to make the API more flexible. In this case, it provides the ability to set page features before edgekit runs