### PR TITLE
Fix Engine evaluate method returning duplicated matched pageViews

### DIFF
--- a/src/engine/evaluate.ts
+++ b/src/engine/evaluate.ts
@@ -7,18 +7,33 @@ import {
   AudienceDefinitionFilter,
 } from '../../types';
 
-export const evaluateCondition = (
-  condition: EngineCondition<AudienceDefinitionFilter>,
-  pageViews: PageView[]
-): boolean => {
-  const { filter, rules } = condition;
-
-  const filteredPageViews = filter.queries.flatMap((query) =>
-    pageViews.filter((pageView) => {
+/* Checks each pageView once for any matching queries
+ * and returns the filtered array containing the matched
+ * pageViews
+ */
+const filterPageViews = (
+  filter: EngineCondition<AudienceDefinitionFilter>['filter'],
+  pageViews: Readonly<PageView[]>
+): PageView[] => {
+  return pageViews.filter(
+    (pageView) => filter.queries.some((query) => {
       const pageFeatures = pageView.features[query.queryProperty];
       return queryMatches(query, pageFeatures);
     })
   );
+};
+
+/* Filter the pageView array by matching queries
+ * and evaluates if it matches the conditions
+ * based on the condition reducing rules
+ */
+export const evaluateCondition = (
+  condition: Readonly<EngineCondition<AudienceDefinitionFilter>>,
+  pageViews: Readonly<PageView[]>
+): boolean => {
+  const { filter, rules } = condition;
+
+  const filteredPageViews = filterPageViews(filter, pageViews)
 
   return rules.every((rule) => {
     // TODO: allow other reducers...
@@ -30,3 +45,7 @@ export const evaluateCondition = (
     return matches(value);
   });
 };
+
+export const testables ={
+  filterPageViews,
+}

--- a/src/engine/evaluate.ts
+++ b/src/engine/evaluate.ts
@@ -15,8 +15,8 @@ const filterPageViews = (
   filter: EngineCondition<AudienceDefinitionFilter>['filter'],
   pageViews: Readonly<PageView[]>
 ): PageView[] => {
-  return pageViews.filter(
-    (pageView) => filter.queries.some((query) => {
+  return pageViews.filter((pageView) =>
+    filter.queries.some((query) => {
       const pageFeatures = pageView.features[query.queryProperty];
       return queryMatches(query, pageFeatures);
     })
@@ -33,7 +33,7 @@ export const evaluateCondition = (
 ): boolean => {
   const { filter, rules } = condition;
 
-  const filteredPageViews = filterPageViews(filter, pageViews)
+  const filteredPageViews = filterPageViews(filter, pageViews);
 
   return rules.every((rule) => {
     // TODO: allow other reducers...
@@ -46,6 +46,6 @@ export const evaluateCondition = (
   });
 };
 
-export const testables ={
+export const testables = {
   filterPageViews,
-}
+};

--- a/src/engine/evaluate.ts
+++ b/src/engine/evaluate.ts
@@ -10,6 +10,10 @@ import {
 /* Checks each pageView once for any matching queries
  * and returns the filtered array containing the matched
  * pageViews
+ *
+ * TODO Here, also, we have an opportunity to implement the
+ * internal AND logic, swapping some for every
+ * according to the value of filter.any
  */
 const filterPageViews = (
   filter: EngineCondition<AudienceDefinitionFilter>['filter'],

--- a/test/engineEvaluate.test.ts
+++ b/test/engineEvaluate.test.ts
@@ -1,0 +1,157 @@
+import { testables } from '../src/engine/evaluate';
+import { makeEngineCondition, makeQuery, makePageView } from './helpers/engineConditions';
+import {
+  QueryFilterComparisonType,
+} from '../types';
+
+const { filterPageViews } = testables;
+
+const multipleOrthogonalQueriesCondition =
+  makeEngineCondition([
+  makeQuery(
+    {
+      vector: [1, 0, 0],
+      threshold: 0.99,
+    },
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+  makeQuery(
+    {
+      vector: [0, 1, 0],
+      threshold: 0.99,
+    },
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+], 1);
+
+const multipleLinearlyDependentQueriesCondition =
+  makeEngineCondition([
+  makeQuery(
+    {
+      vector: [1, 1, 0],
+      threshold: 0.5,
+    },
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+  makeQuery(
+    {
+      vector: [1, 0, 0],
+      threshold: 0.5,
+    },
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+], 1);
+
+describe('Engine evaluate methods', () => {
+  describe('filterPageViews behaviour for Orthogonal audience definitions', () => {
+    // def
+    // [1,0,0], 0.99
+    // [0,1,0], 0.99
+    it('returns pageViews for conditions above threshold', () => {
+      const conditions = multipleOrthogonalQueriesCondition;
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [makePageView([1, 0, 0], 1)]
+        )
+      ).toHaveLength(1);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [makePageView([0, 1, 0], 1)]
+        )
+      ).toHaveLength(1);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [
+            makePageView([1, 0, 0], 1),
+            makePageView([0, 1, 0], 1),
+          ]
+        )
+      ).toHaveLength(2);
+    });
+
+    it('filters off pageViews for conditions below threshold', () => {
+      const conditions = multipleOrthogonalQueriesCondition;
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [
+            makePageView([0, 0, 1], 1),
+            makePageView([1, 1, 1], 1),
+            makePageView([1, 1, 0], 1),
+            makePageView([0, 1, 1], 1),
+          ]
+        )
+      ).toHaveLength(0);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [
+            makePageView([1, 0, 0], 1), // this matches
+            makePageView([1, 1, 1], 1),
+            makePageView([1, 1, 0], 1),
+            makePageView([0, 1, 1], 1),
+          ]
+        )
+      ).toHaveLength(1);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [
+            makePageView([1, 0, 0], 1), // this matches
+            makePageView([0, 1, 0], 1), // this matches
+            makePageView([1, 1, 0], 1),
+            makePageView([0, 1, 1], 1),
+          ]
+        )
+      ).toHaveLength(2);
+    });
+  });
+
+  describe('filterPageViews behaviour for linerly dependent audience definitions', () => {
+    // def
+    // [1,1,0], 0.5
+    // [0,1,0], 0.5
+    it('returns matching pageViews exactly once', () => {
+      const conditions = multipleLinearlyDependentQueriesCondition;
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [makePageView([1, 1, 0], 1)]
+        )
+      ).toHaveLength(1);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [makePageView([0, 1, 0], 1)]
+        )
+      ).toHaveLength(1);
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [
+            makePageView([1, 1, 0], 1),
+            makePageView([0, 1, 0], 1),
+          ]
+        )
+      ).toHaveLength(2);
+    });
+
+    it('does not returns any pageView if no conditions above threshold', () => {
+      const conditions = multipleLinearlyDependentQueriesCondition;
+      expect(
+        filterPageViews(
+          conditions.filter,
+          [ makePageView([0, 0, 1], 1) ]
+        )
+      ).toHaveLength(0);
+    });
+
+  });
+});

--- a/test/engineEvaluate.test.ts
+++ b/test/engineEvaluate.test.ts
@@ -8,7 +8,7 @@ import { QueryFilterComparisonType } from '../types';
 
 const { filterPageViews } = testables;
 
-const multipleOrthogonalQueriesCondition = makeEngineCondition(
+const multipleNonOverlappingQueriesCondition = makeEngineCondition(
   [
     makeQuery(
       {
@@ -30,7 +30,7 @@ const multipleOrthogonalQueriesCondition = makeEngineCondition(
   1
 );
 
-const multipleLinearlyDependentQueriesCondition = makeEngineCondition(
+const multipleOverlappingQueriesCondition = makeEngineCondition(
   [
     makeQuery(
       {
@@ -53,30 +53,27 @@ const multipleLinearlyDependentQueriesCondition = makeEngineCondition(
 );
 
 describe('Engine evaluate methods', () => {
-  describe('filterPageViews behaviour for Orthogonal audience definitions', () => {
-    // def
-    // [1,0,0], 0.99
-    // [0,1,0], 0.99
-    it('returns pageViews for conditions above threshold', () => {
-      const conditions = multipleOrthogonalQueriesCondition;
+  describe('filterPageViews behaviour for non overlapping queries audience definitions', () => {
+    it('returns pageViews for condition above threshold', () => {
+      const condition = multipleOverlappingQueriesCondition;
       expect(
-        filterPageViews(conditions.filter, [makePageView([1, 0, 0], 1)])
+        filterPageViews(condition.filter, [makePageView([1, 0, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(conditions.filter, [makePageView([0, 1, 0], 1)])
+        filterPageViews(condition.filter, [makePageView([0, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(conditions.filter, [
+        filterPageViews(condition.filter, [
           makePageView([1, 0, 0], 1),
           makePageView([0, 1, 0], 1),
         ])
       ).toHaveLength(2);
     });
 
-    it('filters off pageViews for conditions below threshold', () => {
-      const conditions = multipleOrthogonalQueriesCondition;
+    it('filters off pageViews for condition below threshold', () => {
+      const condition = multipleNonOverlappingQueriesCondition;
       expect(
-        filterPageViews(conditions.filter, [
+        filterPageViews(condition.filter, [
           makePageView([0, 0, 1], 1),
           makePageView([1, 1, 1], 1),
           makePageView([1, 1, 0], 1),
@@ -84,7 +81,7 @@ describe('Engine evaluate methods', () => {
         ])
       ).toHaveLength(0);
       expect(
-        filterPageViews(conditions.filter, [
+        filterPageViews(condition.filter, [
           makePageView([1, 0, 0], 1), // this matches
           makePageView([1, 1, 1], 1),
           makePageView([1, 1, 0], 1),
@@ -92,7 +89,7 @@ describe('Engine evaluate methods', () => {
         ])
       ).toHaveLength(1);
       expect(
-        filterPageViews(conditions.filter, [
+        filterPageViews(condition.filter, [
           makePageView([1, 0, 0], 1), // this matches
           makePageView([0, 1, 0], 1), // this matches
           makePageView([1, 1, 0], 1),
@@ -102,30 +99,27 @@ describe('Engine evaluate methods', () => {
     });
   });
 
-  describe('filterPageViews behaviour for linerly dependent audience definitions', () => {
-    // def
-    // [1,1,0], 0.5
-    // [0,1,0], 0.5
+  describe('filterPageViews behaviour for overlapping queries audience definitions', () => {
     it('returns matching pageViews exactly once', () => {
-      const conditions = multipleLinearlyDependentQueriesCondition;
+      const condition = multipleOverlappingQueriesCondition;
       expect(
-        filterPageViews(conditions.filter, [makePageView([1, 1, 0], 1)])
+        filterPageViews(condition.filter, [makePageView([1, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(conditions.filter, [makePageView([0, 1, 0], 1)])
+        filterPageViews(condition.filter, [makePageView([0, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(conditions.filter, [
+        filterPageViews(condition.filter, [
           makePageView([1, 1, 0], 1),
           makePageView([0, 1, 0], 1),
         ])
       ).toHaveLength(2);
     });
 
-    it('does not returns any pageView if no conditions above threshold', () => {
-      const conditions = multipleLinearlyDependentQueriesCondition;
+    it('does not returns any pageView if no condition above threshold', () => {
+      const condition = multipleOverlappingQueriesCondition;
       expect(
-        filterPageViews(conditions.filter, [makePageView([0, 0, 1], 1)])
+        filterPageViews(condition.filter, [makePageView([0, 0, 1], 1)])
       ).toHaveLength(0);
     });
   });

--- a/test/engineEvaluate.test.ts
+++ b/test/engineEvaluate.test.ts
@@ -1,50 +1,56 @@
 import { testables } from '../src/engine/evaluate';
-import { makeEngineCondition, makeQuery, makePageView } from './helpers/engineConditions';
 import {
-  QueryFilterComparisonType,
-} from '../types';
+  makeEngineCondition,
+  makeQuery,
+  makePageView,
+} from './helpers/engineConditions';
+import { QueryFilterComparisonType } from '../types';
 
 const { filterPageViews } = testables;
 
-const multipleOrthogonalQueriesCondition =
-  makeEngineCondition([
-  makeQuery(
-    {
-      vector: [1, 0, 0],
-      threshold: 0.99,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-  makeQuery(
-    {
-      vector: [0, 1, 0],
-      threshold: 0.99,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-], 1);
+const multipleOrthogonalQueriesCondition = makeEngineCondition(
+  [
+    makeQuery(
+      {
+        vector: [1, 0, 0],
+        threshold: 0.99,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+    makeQuery(
+      {
+        vector: [0, 1, 0],
+        threshold: 0.99,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+  ],
+  1
+);
 
-const multipleLinearlyDependentQueriesCondition =
-  makeEngineCondition([
-  makeQuery(
-    {
-      vector: [1, 1, 0],
-      threshold: 0.5,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-  makeQuery(
-    {
-      vector: [1, 0, 0],
-      threshold: 0.5,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-], 1);
+const multipleLinearlyDependentQueriesCondition = makeEngineCondition(
+  [
+    makeQuery(
+      {
+        vector: [1, 1, 0],
+        threshold: 0.5,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+    makeQuery(
+      {
+        vector: [1, 0, 0],
+        threshold: 0.5,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+  ],
+  1
+);
 
 describe('Engine evaluate methods', () => {
   describe('filterPageViews behaviour for Orthogonal audience definitions', () => {
@@ -54,62 +60,44 @@ describe('Engine evaluate methods', () => {
     it('returns pageViews for conditions above threshold', () => {
       const conditions = multipleOrthogonalQueriesCondition;
       expect(
-        filterPageViews(
-          conditions.filter,
-          [makePageView([1, 0, 0], 1)]
-        )
+        filterPageViews(conditions.filter, [makePageView([1, 0, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [makePageView([0, 1, 0], 1)]
-        )
+        filterPageViews(conditions.filter, [makePageView([0, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [
-            makePageView([1, 0, 0], 1),
-            makePageView([0, 1, 0], 1),
-          ]
-        )
+        filterPageViews(conditions.filter, [
+          makePageView([1, 0, 0], 1),
+          makePageView([0, 1, 0], 1),
+        ])
       ).toHaveLength(2);
     });
 
     it('filters off pageViews for conditions below threshold', () => {
       const conditions = multipleOrthogonalQueriesCondition;
       expect(
-        filterPageViews(
-          conditions.filter,
-          [
-            makePageView([0, 0, 1], 1),
-            makePageView([1, 1, 1], 1),
-            makePageView([1, 1, 0], 1),
-            makePageView([0, 1, 1], 1),
-          ]
-        )
+        filterPageViews(conditions.filter, [
+          makePageView([0, 0, 1], 1),
+          makePageView([1, 1, 1], 1),
+          makePageView([1, 1, 0], 1),
+          makePageView([0, 1, 1], 1),
+        ])
       ).toHaveLength(0);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [
-            makePageView([1, 0, 0], 1), // this matches
-            makePageView([1, 1, 1], 1),
-            makePageView([1, 1, 0], 1),
-            makePageView([0, 1, 1], 1),
-          ]
-        )
+        filterPageViews(conditions.filter, [
+          makePageView([1, 0, 0], 1), // this matches
+          makePageView([1, 1, 1], 1),
+          makePageView([1, 1, 0], 1),
+          makePageView([0, 1, 1], 1),
+        ])
       ).toHaveLength(1);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [
-            makePageView([1, 0, 0], 1), // this matches
-            makePageView([0, 1, 0], 1), // this matches
-            makePageView([1, 1, 0], 1),
-            makePageView([0, 1, 1], 1),
-          ]
-        )
+        filterPageViews(conditions.filter, [
+          makePageView([1, 0, 0], 1), // this matches
+          makePageView([0, 1, 0], 1), // this matches
+          makePageView([1, 1, 0], 1),
+          makePageView([0, 1, 1], 1),
+        ])
       ).toHaveLength(2);
     });
   });
@@ -121,37 +109,24 @@ describe('Engine evaluate methods', () => {
     it('returns matching pageViews exactly once', () => {
       const conditions = multipleLinearlyDependentQueriesCondition;
       expect(
-        filterPageViews(
-          conditions.filter,
-          [makePageView([1, 1, 0], 1)]
-        )
+        filterPageViews(conditions.filter, [makePageView([1, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [makePageView([0, 1, 0], 1)]
-        )
+        filterPageViews(conditions.filter, [makePageView([0, 1, 0], 1)])
       ).toHaveLength(1);
       expect(
-        filterPageViews(
-          conditions.filter,
-          [
-            makePageView([1, 1, 0], 1),
-            makePageView([0, 1, 0], 1),
-          ]
-        )
+        filterPageViews(conditions.filter, [
+          makePageView([1, 1, 0], 1),
+          makePageView([0, 1, 0], 1),
+        ])
       ).toHaveLength(2);
     });
 
     it('does not returns any pageView if no conditions above threshold', () => {
       const conditions = multipleLinearlyDependentQueriesCondition;
       expect(
-        filterPageViews(
-          conditions.filter,
-          [ makePageView([0, 0, 1], 1) ]
-        )
+        filterPageViews(conditions.filter, [makePageView([0, 0, 1], 1)])
       ).toHaveLength(0);
     });
-
   });
 });

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -4,23 +4,24 @@ import {
   QueryFilterComparisonType,
   PageView,
   VectorQueryValue,
-  AudienceQueryDefinition
+  AudienceQueryDefinition,
 } from '../../types';
 
 export const makeQuery = <T extends AudienceQueryDefinition>(
   queryValue: VectorQueryValue,
   featureVersion: number,
-  queryFilterComparisonType: QueryFilterComparisonType,
-) => ({
+  queryFilterComparisonType: QueryFilterComparisonType
+) =>
+  ({
     featureVersion,
     queryProperty: 'topicDist',
     queryFilterComparisonType,
     queryValue,
-}) as EngineConditionQuery<T>
+  } as EngineConditionQuery<T>);
 
 export const makeEngineCondition = <T extends AudienceQueryDefinition>(
   queries: EngineConditionQuery<T>[],
-  occurences: number,
+  occurences: number
 ): EngineCondition<T> => ({
   filter: { queries },
   rules: [
@@ -36,10 +37,7 @@ export const makeEngineCondition = <T extends AudienceQueryDefinition>(
   ],
 });
 
-export const makePageView = (
-  value: number[],
-  version: number
-): PageView => ({
+export const makePageView = (value: number[], version: number): PageView => ({
   ts: 100,
   features: {
     topicDist: {
@@ -47,4 +45,4 @@ export const makePageView = (
       value,
     },
   },
-})
+});

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -11,7 +11,7 @@ export const makeQuery = <T extends AudienceQueryDefinition>(
   queryValue: VectorQueryValue,
   featureVersion: number,
   queryFilterComparisonType: QueryFilterComparisonType
-) =>
+): EngineConditionQuery<T> =>
   ({
     featureVersion,
     queryProperty: 'topicDist',

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -1,0 +1,50 @@
+import {
+  EngineCondition,
+  EngineConditionQuery,
+  QueryFilterComparisonType,
+  PageView,
+  VectorQueryValue,
+  AudienceQueryDefinition
+} from '../../types';
+
+export const makeQuery = <T extends AudienceQueryDefinition>(
+  queryValue: VectorQueryValue,
+  featureVersion: number,
+  queryFilterComparisonType: QueryFilterComparisonType,
+) => ({
+    featureVersion,
+    queryProperty: 'topicDist',
+    queryFilterComparisonType,
+    queryValue,
+}) as EngineConditionQuery<T>
+
+export const makeEngineCondition = <T extends AudienceQueryDefinition>(
+  queries: EngineConditionQuery<T>[],
+  occurences: number,
+): EngineCondition<T> => ({
+  filter: { queries },
+  rules: [
+    {
+      reducer: {
+        name: 'count',
+      },
+      matcher: {
+        name: 'ge',
+        args: occurences,
+      },
+    },
+  ],
+});
+
+export const makePageView = (
+  value: number[],
+  version: number
+): PageView => ({
+  ts: 100,
+  features: {
+    topicDist: {
+      version,
+      value,
+    },
+  },
+})

--- a/test/multipleQueriesEngineCondition.test.ts
+++ b/test/multipleQueriesEngineCondition.test.ts
@@ -1,103 +1,89 @@
 import { check } from '../src/engine';
-import {
-  EngineCondition,
-  QueryFilterComparisonType,
-  CosineSimilarityFilter,
-  PageView,
-} from '../types';
+import { makeEngineCondition, makeQuery, makePageView } from './helpers/engineConditions';
+import { QueryFilterComparisonType, } from '../types';
 
-const multipleSameTypeQueriesCondition: EngineCondition<CosineSimilarityFilter> = {
-  filter: {
-    queries: [
-      {
-        featureVersion: 1,
-        queryProperty: 'topicDist',
-        queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY,
-        queryValue: {
-          vector: [1, 1, 1],
-          threshold: 0.99,
-        },
-      },
-      {
-        featureVersion: 1,
-        queryProperty: 'topicDist',
-        queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY,
-        queryValue: {
-          vector: [1, 0, 1],
-          threshold: 0.99,
-        },
-      },
-    ],
-  },
-  rules: [
+const multipleOrthogonalQueriesCondition =
+  makeEngineCondition([
+  makeQuery(
     {
-      reducer: {
-        name: 'count',
-      },
-      matcher: {
-        name: 'ge',
-        args: 1,
-      },
+      vector: [0, 1, 0],
+      threshold: 0.99,
     },
-  ],
-};
-
-const makePageView = (value: number[], version: number): PageView[] => [
-  {
-    ts: 100,
-    features: {
-      topicDist: {
-        version,
-        value,
-      },
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+  makeQuery(
+    {
+      vector: [1, 0, 0],
+      threshold: 0.99,
     },
-  },
-];
+    1,
+    QueryFilterComparisonType.COSINE_SIMILARITY
+  ),
+], 1);
 
 describe('Multiple EngineConditionQuery values test', () => {
   describe('Multiple CosineSimilarity filter conditions query', () => {
     it('matches for condition above threshold on fisrt query object', () => {
-      const conditions = [multipleSameTypeQueriesCondition];
-      const pageViews = makePageView([1, 1, 1], 1);
+      const conditions = [multipleOrthogonalQueriesCondition];
+      const pageViews = [makePageView([1, 0, 0], 1)];
       const result = check(conditions, pageViews);
       expect(result).toEqual(true);
     });
 
     it('matches for condition above threshold on second query object', () => {
-      const conditions = [multipleSameTypeQueriesCondition];
-      const pageViews = makePageView([1, 0, 1], 1);
+      const conditions = [multipleOrthogonalQueriesCondition];
+      const pageViews = [makePageView([0, 1, 0], 1)];
       const result = check(conditions, pageViews);
       expect(result).toEqual(true);
     });
 
     it('does not matches for condition below threshold on every query object', () => {
-      const conditions = [multipleSameTypeQueriesCondition];
-      const pageViews = makePageView([0, 1, 0], 1);
-      const result = check(conditions, pageViews, true);
-      expect(result).toEqual(false);
-    });
-
-    it('matches for condition above threshold on any pageView object - condition pair', () => {
-      const conditions = [multipleSameTypeQueriesCondition];
-      expect(
-        check(conditions, [
-          ...makePageView([0, 1, 0], 1),
-          ...makePageView([1, 0, 1], 1),
-        ])
-      ).toEqual(true);
-      expect(
-        check(conditions, [
-          ...makePageView([1, 1, 1], 1),
-          ...makePageView([0, 1, 0], 1),
-        ])
-      ).toEqual(true);
-    });
-
-    it('does not matches for different condition - pageView versions', () => {
-      const conditions = [multipleSameTypeQueriesCondition];
-      const pageViews = makePageView([1, 1, 1], 2);
+      const conditions = [multipleOrthogonalQueriesCondition];
+      const pageViews = [makePageView([0, 0, 1], 1)];
       const result = check(conditions, pageViews);
       expect(result).toEqual(false);
+    });
+
+    it('matches for condition above threshold on at least one (pageView, condition) pair', () => {
+      const conditions = [multipleOrthogonalQueriesCondition];
+      expect(
+        check(conditions, [
+          makePageView([1, 0, 0], 1),
+          makePageView([0, 0, 1], 1),
+        ])
+      ).toEqual(true);
+      expect(
+        check(conditions, [
+          makePageView([0, 1, 0], 1),
+          makePageView([0, 0, 1], 1),
+        ])
+      ).toEqual(true);
+    });
+
+    it('does not matches for different (condition, pageView) versions attributes', () => {
+      const conditions = [multipleOrthogonalQueriesCondition];
+      const pageViews = [
+        makePageView([1, 0, 0], 2),
+        makePageView([0, 1, 0], 2),
+        makePageView([0, 0, 1], 2),
+        makePageView([1, 1, 1], 2),
+      ];
+      const result = check(conditions, pageViews);
+      expect(result).toEqual(false);
+    });
+
+
+    it('successfully matches for mixed versions/conditions', () => {
+      const conditions = [multipleOrthogonalQueriesCondition];
+      const pageViews = [
+        makePageView([1, 0, 0], 1),
+        makePageView([0, 1, 0], 2),
+        makePageView([0, 0, 1], 2),
+        makePageView([1, 1, 1], 2),
+      ];
+      const result = check(conditions, pageViews);
+      expect(result).toEqual(true);
     });
   });
 });

--- a/test/multipleQueriesEngineCondition.test.ts
+++ b/test/multipleQueriesEngineCondition.test.ts
@@ -1,26 +1,32 @@
 import { check } from '../src/engine';
-import { makeEngineCondition, makeQuery, makePageView } from './helpers/engineConditions';
-import { QueryFilterComparisonType, } from '../types';
+import {
+  makeEngineCondition,
+  makeQuery,
+  makePageView,
+} from './helpers/engineConditions';
+import { QueryFilterComparisonType } from '../types';
 
-const multipleOrthogonalQueriesCondition =
-  makeEngineCondition([
-  makeQuery(
-    {
-      vector: [0, 1, 0],
-      threshold: 0.99,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-  makeQuery(
-    {
-      vector: [1, 0, 0],
-      threshold: 0.99,
-    },
-    1,
-    QueryFilterComparisonType.COSINE_SIMILARITY
-  ),
-], 1);
+const multipleOrthogonalQueriesCondition = makeEngineCondition(
+  [
+    makeQuery(
+      {
+        vector: [0, 1, 0],
+        threshold: 0.99,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+    makeQuery(
+      {
+        vector: [1, 0, 0],
+        threshold: 0.99,
+      },
+      1,
+      QueryFilterComparisonType.COSINE_SIMILARITY
+    ),
+  ],
+  1
+);
 
 describe('Multiple EngineConditionQuery values test', () => {
   describe('Multiple CosineSimilarity filter conditions query', () => {
@@ -72,7 +78,6 @@ describe('Multiple EngineConditionQuery values test', () => {
       const result = check(conditions, pageViews);
       expect(result).toEqual(false);
     });
-
 
     it('successfully matches for mixed versions/conditions', () => {
       const conditions = [multipleOrthogonalQueriesCondition];


### PR DESCRIPTION
Fix Engine evaluate method returning duplicated matched `pageViews`
Adds tests to internal `evaluateCondition` methods

# Summary

Closes # https://github.com/AirGrid/edgekit/issues/102

## Type of change

- [x] Bugfix (non-breaking change which fix functionality not working as expected)

## How Has This Been Tested?

- [x] full test suite

## Checklist:


- [x] I have updated the PR title to something descriptive.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.