### PR TITLE
Delete unused features from users local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:watch": "jest --watch --verbose",
     "test:coverage": "jest --coverage",
     "lint": "eslint src test --ext js,ts",
-    "lint:fix": "lint --fix"
+    "lint:fix": "eslint src test --ext js,ts --fix"
   },
   "devDependencies": {
     "@types/jest": "^26.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ interface Config {
   pageMetadata?: Record<string, string | number | boolean>;
   vendorIds?: number[];
   omitGdprConsent?: boolean;
-  featureMaxAge?: number;
   featureStorageSize?: number;
 }
 
@@ -26,19 +25,16 @@ const run = async (config: Config): Promise<void> => {
     pageMetadata,
     omitGdprConsent,
     audienceDefinitions,
-    featureMaxAge,
     featureStorageSize,
   } = config;
-
-  // This is a no-op if undefined, equals current value or lesser than 0
-  viewStore.setMaxAge(featureMaxAge)
-  viewStore.setStoreSize(featureStorageSize)
 
   if (!omitGdprConsent) {
     const hasConsent = await waitForConsent(vendorIds);
     if (!hasConsent) return;
   }
 
+  // This is a no-op if undefined, equals current value or lesser than 0
+  viewStore.setStorageSize(featureStorageSize)
   viewStore.insert(pageFeatures, pageMetadata);
 
   const matchedAudiences = audienceDefinitions

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ interface Config {
   pageMetadata?: Record<string, string | number | boolean>;
   vendorIds?: number[];
   omitGdprConsent?: boolean;
+  featureMaxAge?: number;
+  featureStorageSize?: number;
 }
 
 const run = async (config: Config): Promise<void> => {
@@ -24,7 +26,13 @@ const run = async (config: Config): Promise<void> => {
     pageMetadata,
     omitGdprConsent,
     audienceDefinitions,
+    featureMaxAge,
+    featureStorageSize,
   } = config;
+
+  // This is a no-op if equals current value or lesser than 0
+  viewStore.setMaxAge(featureMaxAge)
+  viewStore.setStoreSize(featureStorageSize)
 
   if (!omitGdprConsent) {
     const hasConsent = await waitForConsent(vendorIds);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const run = async (config: Config): Promise<void> => {
     featureStorageSize,
   } = config;
 
-  // This is a no-op if equals current value or lesser than 0
+  // This is a no-op if undefined, equals current value or lesser than 0
   viewStore.setMaxAge(featureMaxAge)
   viewStore.setStoreSize(featureStorageSize)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const run = async (config: Config): Promise<void> => {
   }
 
   // This is a no-op if undefined, equals current value or lesser than 0
-  viewStore.setStorageSize(featureStorageSize)
+  viewStore.setStorageSize(featureStorageSize);
   viewStore.insert(pageFeatures, pageMetadata);
 
   const matchedAudiences = audienceDefinitions

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -4,12 +4,25 @@ import { PageView, StorageKeys, PageFeatureResult } from '../../types';
 class ViewStore {
   pageViews: PageView[];
   maxAge: number;
+  storageSize: number;
 
-  constructor(maxAge: number) {
+  constructor(maxAge: number, storageSize: number) {
     this.pageViews = [];
     this._trim();
-    this._load();
     this.maxAge = maxAge;
+    this.storageSize = storageSize;
+  }
+
+  setMaxAge(maxAge: number) {
+    if (maxAge < 0) return
+    this.maxAge = maxAge;
+    this._trim()
+  }
+
+  setStoreSize(storageSize: number) {
+    if (storageSize < 0) return
+    this.storageSize = storageSize;
+    this._trim()
   }
 
   _load() {
@@ -23,12 +36,16 @@ class ViewStore {
   _trim() {
     const pageViews = storage.get(StorageKeys.PAGE_VIEWS) || [];
     pageViews.sort(
-      (a: PageView, b: PageView): number => a.ts - b.ts
+      (a: PageView, b: PageView): number => b.ts - a.ts
     )
     const filteredPageViews = pageViews.filter(
-      (pageView: PageView) => pageView.ts > timeStampInSecs() - this.maxAge
+      (pageView: PageView, i: number) =>
+        pageView.ts > timeStampInSecs() - this.maxAge && i < this.storageSize
     )
-    storage.set(StorageKeys.PAGE_VIEWS, filteredPageViews)
+    storage.set(
+      StorageKeys.PAGE_VIEWS,
+      filteredPageViews
+    )
     this._load()
   }
 
@@ -48,4 +65,5 @@ class ViewStore {
   }
 }
 
-export const viewStore = new ViewStore(1000);
+// defaults to 10 days old and 10k items storageSize
+export const viewStore = new ViewStore(3600 * 24 * 30, 10000);

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -6,12 +6,16 @@ class ViewStore {
   maxAge: number;
   storageSize: number;
 
-  constructor(maxAge: number, storageSize: number) {
+  constructor(maxAge?: number, storageSize?: number) {
     this.pageViews = [];
-    this.maxAge = maxAge;
-    this.storageSize = storageSize;
+    // TODO define sane defaults for maxAge and storageSize and update tests it will break
+    // this.maxAge = maxAge ?? 3600 * 24 * 30;
+    // this.storageSize = storageSize ?? 10000;
+    this.maxAge = maxAge ?? Infinity;
+    this.storageSize = storageSize ?? Infinity;
     this._load();
     this._trim();
+    this._save();
   }
 
   _load() {
@@ -28,19 +32,21 @@ class ViewStore {
       (pageView: PageView, i: number) =>
         pageView.ts > timeStampInSecs() - this.maxAge && i < this.storageSize
     );
+  }
+
+  setMaxAge(maxAge?: number) {
+    if (!maxAge || maxAge < 0 || maxAge === this.maxAge) return;
+    this.maxAge = maxAge;
+    this._trim();
     this._save();
   }
 
-  setMaxAge(maxAge: number) {
-    if (maxAge < 0) return;
-    this.maxAge = maxAge;
-    this._trim();
-  }
-
-  setStoreSize(storageSize: number) {
-    if (storageSize < 0) return;
+  setStoreSize(storageSize?: number) {
+    if (!storageSize || storageSize < 0 || storageSize === this.storageSize)
+      return;
     this.storageSize = storageSize;
     this._trim();
+    this._save();
   }
 
   insert(
@@ -55,9 +61,9 @@ class ViewStore {
       ...metadata,
     };
     this.pageViews.push(pageView);
+    this._trim();
     this._save();
   }
 }
 
-// defaults to 10 days old and 10k items storageSize
-export const viewStore = new ViewStore(3600 * 24 * 30, 10000);
+export const viewStore = new ViewStore();

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -3,16 +3,13 @@ import { PageView, StorageKeys, PageFeatureResult } from '../../types';
 
 class ViewStore {
   pageViews: PageView[];
-  maxAge: number;
   storageSize: number;
 
   /**
-   * @param maxAge Max pageView age to be kept in seconds
    * @param storageSize Max pageView items to be kept
    */
-  constructor(maxAge?: number, storageSize?: number) {
+  constructor(storageSize?: number) {
     this.pageViews = [];
-    this.maxAge = maxAge ?? Infinity;
     this.storageSize = storageSize ?? Infinity;
     this._load();
   }
@@ -26,28 +23,15 @@ class ViewStore {
   }
 
   _trim() {
-    const validUntil = timeStampInSecs() - this.maxAge;
     this.pageViews.sort((a: PageView, b: PageView): number => b.ts - a.ts);
-    this.pageViews = this.pageViews.filter(
-      (pageView: PageView, i: number) =>
-        pageView.ts > validUntil && i < this.storageSize
-    );
-  }
-
-  /**
-   * @param maxAge Max pageView age to be kept in seconds
-   */
-  setMaxAge(maxAge?: number) {
-    if (!maxAge || maxAge < 0 || maxAge === this.maxAge) return;
-    this.maxAge = maxAge;
+    this.pageViews = this.pageViews.slice(0, this.storageSize)
   }
 
   /**
    * @param storageSize Max pageView items to be kept
    */
-  setStoreSize(storageSize?: number) {
-    if (!storageSize || storageSize < 0 || storageSize === this.storageSize)
-      return;
+  setStorageSize(storageSize?: number) {
+    if (!storageSize || storageSize < 0) return;
     this.storageSize = storageSize;
   }
 
@@ -68,4 +52,4 @@ class ViewStore {
   }
 }
 
-export const viewStore = new ViewStore(3600 * 24 * 45, 300);
+export const viewStore = new ViewStore(300);

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -7,12 +7,9 @@ class ViewStore {
   pageViews: PageView[];
   storageSize: number;
 
-  /**
-   * @param storageSize Max pageView items to be kept
-   */
-  constructor(storageSize?: number) {
+  constructor() {
     this.pageViews = [];
-    this.storageSize = storageSize ?? DEFAULT_MAX_FEATURES_SIZE;
+    this.storageSize = DEFAULT_MAX_FEATURES_SIZE;
     this._load();
   }
 
@@ -27,7 +24,7 @@ class ViewStore {
   _trim() {
     if (this.pageViews.length <= this.storageSize) return;
     this.pageViews.sort((a: PageView, b: PageView): number => b.ts - a.ts);
-    this.pageViews = this.pageViews.slice(0, this.storageSize)
+    this.pageViews = this.pageViews.slice(0, this.storageSize);
   }
 
   /**

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -3,10 +3,13 @@ import { PageView, StorageKeys, PageFeatureResult } from '../../types';
 
 class ViewStore {
   pageViews: PageView[];
+  maxAge: number;
 
-  constructor() {
+  constructor(maxAge: number) {
     this.pageViews = [];
+    this._trim();
     this._load();
+    this.maxAge = maxAge;
   }
 
   _load() {
@@ -15,6 +18,18 @@ class ViewStore {
 
   _save() {
     storage.set(StorageKeys.PAGE_VIEWS, this.pageViews);
+  }
+
+  _trim() {
+    const pageViews = storage.get(StorageKeys.PAGE_VIEWS) || [];
+    pageViews.sort(
+      (a: PageView, b: PageView): number => a.ts - b.ts
+    )
+    const filteredPageViews = pageViews.filter(
+      (pageView: PageView) => pageView.ts > timeStampInSecs() - this.maxAge
+    )
+    storage.set(StorageKeys.PAGE_VIEWS, filteredPageViews)
+    this._load()
   }
 
   insert(
@@ -33,4 +48,4 @@ class ViewStore {
   }
 }
 
-export const viewStore = new ViewStore();
+export const viewStore = new ViewStore(1000);

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -1,6 +1,8 @@
 import { storage, timeStampInSecs } from '../utils';
 import { PageView, StorageKeys, PageFeatureResult } from '../../types';
 
+const DEFAULT_MAX_FEATURES_SIZE = 300;
+
 class ViewStore {
   pageViews: PageView[];
   storageSize: number;
@@ -10,7 +12,7 @@ class ViewStore {
    */
   constructor(storageSize?: number) {
     this.pageViews = [];
-    this.storageSize = storageSize ?? Infinity;
+    this.storageSize = storageSize ?? DEFAULT_MAX_FEATURES_SIZE;
     this._load();
   }
 
@@ -23,6 +25,7 @@ class ViewStore {
   }
 
   _trim() {
+    if (this.pageViews.length <= this.storageSize) return;
     this.pageViews.sort((a: PageView, b: PageView): number => b.ts - a.ts);
     this.pageViews = this.pageViews.slice(0, this.storageSize)
   }
@@ -52,4 +55,4 @@ class ViewStore {
   }
 }
 
-export const viewStore = new ViewStore(300);
+export const viewStore = new ViewStore();

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -6,16 +6,15 @@ class ViewStore {
   maxAge: number;
   storageSize: number;
 
+  /**
+   * @param maxAge Max pageView age to be kept in seconds
+   * @param storageSize Max pageView items to be kept
+   */
   constructor(maxAge?: number, storageSize?: number) {
     this.pageViews = [];
-    // TODO define sane defaults for maxAge and storageSize and update tests it will break
-    // this.maxAge = maxAge ?? 3600 * 24 * 30;
-    // this.storageSize = storageSize ?? 10000;
     this.maxAge = maxAge ?? Infinity;
     this.storageSize = storageSize ?? Infinity;
     this._load();
-    this._trim();
-    this._save();
   }
 
   _load() {
@@ -27,26 +26,29 @@ class ViewStore {
   }
 
   _trim() {
+    const validUntil = timeStampInSecs() - this.maxAge;
     this.pageViews.sort((a: PageView, b: PageView): number => b.ts - a.ts);
     this.pageViews = this.pageViews.filter(
       (pageView: PageView, i: number) =>
-        pageView.ts > timeStampInSecs() - this.maxAge && i < this.storageSize
+        pageView.ts > validUntil && i < this.storageSize
     );
   }
 
+  /**
+   * @param maxAge Max pageView age to be kept in seconds
+   */
   setMaxAge(maxAge?: number) {
     if (!maxAge || maxAge < 0 || maxAge === this.maxAge) return;
     this.maxAge = maxAge;
-    this._trim();
-    this._save();
   }
 
+  /**
+   * @param storageSize Max pageView items to be kept
+   */
   setStoreSize(storageSize?: number) {
     if (!storageSize || storageSize < 0 || storageSize === this.storageSize)
       return;
     this.storageSize = storageSize;
-    this._trim();
-    this._save();
   }
 
   insert(
@@ -66,4 +68,4 @@ class ViewStore {
   }
 }
 
-export const viewStore = new ViewStore();
+export const viewStore = new ViewStore(3600 * 24 * 45, 300);

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -8,21 +8,10 @@ class ViewStore {
 
   constructor(maxAge: number, storageSize: number) {
     this.pageViews = [];
+    this.maxAge = maxAge;
+    this.storageSize = storageSize;
+    this._load();
     this._trim();
-    this.maxAge = maxAge;
-    this.storageSize = storageSize;
-  }
-
-  setMaxAge(maxAge: number) {
-    if (maxAge < 0) return
-    this.maxAge = maxAge;
-    this._trim()
-  }
-
-  setStoreSize(storageSize: number) {
-    if (storageSize < 0) return
-    this.storageSize = storageSize;
-    this._trim()
   }
 
   _load() {
@@ -34,19 +23,24 @@ class ViewStore {
   }
 
   _trim() {
-    const pageViews = storage.get(StorageKeys.PAGE_VIEWS) || [];
-    pageViews.sort(
-      (a: PageView, b: PageView): number => b.ts - a.ts
-    )
-    const filteredPageViews = pageViews.filter(
+    this.pageViews.sort((a: PageView, b: PageView): number => b.ts - a.ts);
+    this.pageViews = this.pageViews.filter(
       (pageView: PageView, i: number) =>
         pageView.ts > timeStampInSecs() - this.maxAge && i < this.storageSize
-    )
-    storage.set(
-      StorageKeys.PAGE_VIEWS,
-      filteredPageViews
-    )
-    this._load()
+    );
+    this._save();
+  }
+
+  setMaxAge(maxAge: number) {
+    if (maxAge < 0) return;
+    this.maxAge = maxAge;
+    this._trim();
+  }
+
+  setStoreSize(storageSize: number) {
+    if (storageSize < 0) return;
+    this.storageSize = storageSize;
+    this._trim();
   }
 
   insert(

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -31,7 +31,7 @@ describe('ViewStore cleaning behaviour', () => {
 
   it('should delete old pageView entries beyond maxAge on new config value', async () => {
     // Defaults to Infinity for now...
-    // viewStore.setMaxAge(1000000000000000)
+    viewStore.setMaxAge(Infinity)
 
     // Stub Date object
     jest

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -2,7 +2,7 @@ import { viewStore } from '../src/store';
 import { edkt } from '../src';
 import { getPageViews } from './helpers/localStorageSetup';
 
-describe('feature cleaning behaviour', () => {
+describe('ViewStore cleaning behaviour', () => {
   const vendorIds = [873];
   const omitGdprConsent = true;
 
@@ -20,7 +20,8 @@ describe('feature cleaning behaviour', () => {
     },
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
+    localStorage.clear();
     viewStore._load();
   });
 
@@ -28,7 +29,7 @@ describe('feature cleaning behaviour', () => {
     localStorage.clear();
   });
 
-  it('should delete old pageView entries', async () => {
+  it('should delete old pageView entries beyond maxAge', async () => {
 
     // Stub Date object
     jest.spyOn(global.Date, 'now')
@@ -59,7 +60,7 @@ describe('feature cleaning behaviour', () => {
     expect(getPageViews()).toHaveLength(2)
 
     // the module is loaded again
-    viewStore._trim()
+    viewStore.setMaxAge(3600 * 24 * 60)
 
     const edktPageViews = getPageViews();
 
@@ -67,6 +68,57 @@ describe('feature cleaning behaviour', () => {
       {
         features: newFeatures,
         ts: edktPageViews[0].ts,
+      },
+    ]);
+  });
+
+  it('should delete old pageView entries beyond maxStorageSize', async () => {
+
+    for (let i = 1; i < 9; i++) {
+      // Stub Date object
+      jest.spyOn(global.Date, 'now')
+      .mockImplementationOnce(
+        () => new Date(`2020-12-0${i}T09:00:00.333Z`).valueOf()
+      )
+      // runs fist time in 1982
+      await edkt.run({
+        pageFeatures: oldFeatures,
+        audienceDefinitions: [],
+        omitGdprConsent,
+        vendorIds,
+      });
+    }
+
+    expect(getPageViews()).toHaveLength(8)
+
+    // run second time with current timestamp
+    await edkt.run({
+      pageFeatures: newFeatures,
+      audienceDefinitions: [],
+      omitGdprConsent,
+      vendorIds,
+    });
+
+    expect(getPageViews()).toHaveLength(9)
+
+    // change module config
+    viewStore.setStoreSize(3)
+
+    const edktPageViews = getPageViews();
+
+    expect(edktPageViews).toHaveLength(3)
+    expect(edktPageViews).toEqual([
+      {
+        features: newFeatures,
+        ts: edktPageViews[0].ts,
+      },
+      {
+        features: oldFeatures,
+        ts: Math.round(new Date('2020-12-08T09:00:00.333Z').valueOf() / 1000),
+      },
+      {
+        features: oldFeatures,
+        ts: Math.round(new Date('2020-12-07T09:00:00.333Z').valueOf() / 1000),
       },
     ]);
   });

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -29,70 +29,16 @@ describe('ViewStore cleaning behaviour', () => {
     localStorage.clear();
   });
 
-  it('should delete old pageView entries beyond maxAge on new config value', async () => {
-    // Defaults to Infinity for now...
-    viewStore.setMaxAge(Infinity)
-
-    // Stub Date object
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date('1982-09-01T09:00:00.333Z').valueOf()
-      );
-
-    // runs fist time in 1982
-    await edkt.run({
-      pageFeatures: oldFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-    });
-
-    expect(getPageViews()).toHaveLength(1);
-
-    // time has passed...
-
-    // run second time with current timestamp
-    await edkt.run({
-      pageFeatures: newFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-    });
-
-    expect(getPageViews()).toHaveLength(2);
-
-    // run third time with new config
-    await edkt.run({
-      pageFeatures: newFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-      featureMaxAge: 3600 * 24 * 60,
-    });
-
-    expect(getPageViews()).toHaveLength(2);
-
-    const edktPageViews = getPageViews();
-    expect(edktPageViews).toEqual([
-      {
-        features: newFeatures,
-        ts: edktPageViews[0].ts,
-      },
-      {
-        features: newFeatures,
-        ts: edktPageViews[1].ts,
-      },
-    ]);
-  });
-
   it('should delete old pageView entries beyond maxStorageSize', async () => {
+
+    viewStore.setStorageSize(Infinity)
+
     for (let i = 1; i < 9; i++) {
       // Stub Date object
       jest
         .spyOn(global.Date, 'now')
         .mockImplementationOnce(() =>
-          new Date(`2020-12-0${i}T09:00:00.333Z`).valueOf()
+          new Date(`2000-12-0${i}T09:00:00.333Z`).valueOf()
         );
       await edkt.run({
         pageFeatures: oldFeatures,
@@ -104,7 +50,11 @@ describe('ViewStore cleaning behaviour', () => {
 
     expect(getPageViews()).toHaveLength(8);
 
-    // runs with current timestamp
+    // runs with newer timestamp
+    const newerDate = new Date(`2010-12-01T09:00:00.333Z`).valueOf()
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() => newerDate);
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
@@ -133,22 +83,21 @@ describe('ViewStore cleaning behaviour', () => {
       },
       {
         features: newFeatures,
-        ts: edktPageViews[1].ts,
+        ts: Math.round(newerDate / 1000),
       },
       {
         features: oldFeatures,
-        ts: Math.round(new Date('2020-12-08T09:00:00.333Z').valueOf() / 1000),
+        ts: Math.round(new Date('2000-12-08T09:00:00.333Z').valueOf() / 1000),
       },
     ]);
   });
 
   it('should trim pageViews beyond limit while accepting new entries', async () => {
     for (let i = 1; i < 9; i++) {
-      // Stub Date object
       jest
         .spyOn(global.Date, 'now')
         .mockImplementationOnce(() =>
-          new Date(`2020-12-0${i}T09:00:00.333Z`).valueOf()
+          new Date(`2000-12-0${i}T09:00:00.333Z`).valueOf()
         );
       await edkt.run({
         pageFeatures: oldFeatures,
@@ -161,6 +110,10 @@ describe('ViewStore cleaning behaviour', () => {
 
     expect(getPageViews()).toHaveLength(5);
 
+    const newerDate = new Date(`2010-12-01T09:00:00.333Z`).valueOf()
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() => newerDate);
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
@@ -169,48 +122,8 @@ describe('ViewStore cleaning behaviour', () => {
       featureStorageSize: 6,
     });
 
-    expect(getPageViews()).toHaveLength(6);
-  });
-
-  it('should reject entries containing ts beyond maxAge and should keep last config value', async () => {
-    // Stub Date object
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date(`1978-12-01T09:00:00.333Z`).valueOf()
-      );
-    await edkt.run({
-      pageFeatures: oldFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-      featureMaxAge: 3600 * 24,
-    });
-
-    expect(getPageViews()).toHaveLength(0);
-
-    await edkt.run({
-      pageFeatures: newFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-    });
-
-    expect(getPageViews()).toHaveLength(1);
-
-    // Stub Date object
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() =>
-        new Date(`1978-12-01T09:00:00.333Z`).valueOf()
-      );
-    await edkt.run({
-      pageFeatures: oldFeatures,
-      audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
-    });
-
-    expect(getPageViews()).toHaveLength(1);
+    const pageViews = getPageViews()
+    expect(pageViews).toHaveLength(6);
+    expect(pageViews[0].ts).toEqual(Math.round(newerDate / 1000))
   });
 });

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -30,8 +30,7 @@ describe('ViewStore cleaning behaviour', () => {
   });
 
   it('should delete old pageView entries beyond maxStorageSize', async () => {
-
-    viewStore.setStorageSize(Infinity)
+    viewStore.setStorageSize(Infinity);
 
     for (let i = 1; i < 9; i++) {
       // Stub Date object
@@ -51,10 +50,8 @@ describe('ViewStore cleaning behaviour', () => {
     expect(getPageViews()).toHaveLength(8);
 
     // runs with newer timestamp
-    const newerDate = new Date(`2010-12-01T09:00:00.333Z`).valueOf()
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() => newerDate);
+    const newerDate = new Date(`2010-12-01T09:00:00.333Z`).valueOf();
+    jest.spyOn(global.Date, 'now').mockImplementationOnce(() => newerDate);
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
@@ -113,7 +110,7 @@ describe('ViewStore cleaning behaviour', () => {
       featureStorageSize: 6,
     });
 
-    const pageViews = getPageViews()
+    const pageViews = getPageViews();
     expect(pageViews).toHaveLength(6);
   });
 });

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -1,0 +1,62 @@
+import { viewStore } from '../src/store';
+import { edkt } from '../src';
+import { getPageViews } from './helpers/localStorageSetup';
+
+describe('feature cleaning behaviour', () => {
+  const vendorIds = [873];
+  const omitGdprConsent = true;
+
+  const oldFeatures = {
+    keywords: {
+      version: 1,
+      value: ['Haskell Curry', 'death', 'combinatory logic'],
+    },
+  };
+
+  const newFeatures = {
+    keywords: {
+      version: 1,
+      value: ['virus', 'politics', 'ai'],
+    },
+  };
+
+  beforeAll(() => {
+    viewStore._load();
+  });
+
+  afterAll(() => {
+    localStorage.clear();
+  });
+
+  it('should set the page features in the store', async () => {
+    jest.spyOn(global.Date, 'now')
+    .mockImplementationOnce(
+      () => new Date('1982-09-01T09:00:00.333Z').valueOf()
+    )
+
+    // runs fist time in 1982
+    await edkt.run({
+      pageFeatures: oldFeatures,
+      audienceDefinitions: [],
+      omitGdprConsent,
+      vendorIds,
+    });
+
+    // run second time with current timestamp
+    await edkt.run({
+      pageFeatures: newFeatures,
+      audienceDefinitions: [],
+      omitGdprConsent,
+      vendorIds,
+    });
+
+    const edktPageViews = getPageViews();
+
+    expect(edktPageViews).toEqual([
+      {
+        features: newFeatures,
+        ts: edktPageViews[0].ts,
+      },
+    ]);
+  });
+});

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -28,7 +28,9 @@ describe('feature cleaning behaviour', () => {
     localStorage.clear();
   });
 
-  it('should set the page features in the store', async () => {
+  it('should delete old pageView entries', async () => {
+
+    // Stub Date object
     jest.spyOn(global.Date, 'now')
     .mockImplementationOnce(
       () => new Date('1982-09-01T09:00:00.333Z').valueOf()
@@ -42,6 +44,10 @@ describe('feature cleaning behaviour', () => {
       vendorIds,
     });
 
+    expect(getPageViews()).toHaveLength(1)
+
+    // time has passed...
+
     // run second time with current timestamp
     await edkt.run({
       pageFeatures: newFeatures,
@@ -49,6 +55,11 @@ describe('feature cleaning behaviour', () => {
       omitGdprConsent,
       vendorIds,
     });
+
+    expect(getPageViews()).toHaveLength(2)
+
+    // the module is loaded again
+    viewStore._trim()
 
     const edktPageViews = getPageViews();
 

--- a/test/deleteUnusedFeatures.test.ts
+++ b/test/deleteUnusedFeatures.test.ts
@@ -94,11 +94,6 @@ describe('ViewStore cleaning behaviour', () => {
 
   it('should trim pageViews beyond limit while accepting new entries', async () => {
     for (let i = 1; i < 9; i++) {
-      jest
-        .spyOn(global.Date, 'now')
-        .mockImplementationOnce(() =>
-          new Date(`2000-12-0${i}T09:00:00.333Z`).valueOf()
-        );
       await edkt.run({
         pageFeatures: oldFeatures,
         audienceDefinitions: [],
@@ -110,10 +105,6 @@ describe('ViewStore cleaning behaviour', () => {
 
     expect(getPageViews()).toHaveLength(5);
 
-    const newerDate = new Date(`2010-12-01T09:00:00.333Z`).valueOf()
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementationOnce(() => newerDate);
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
@@ -124,6 +115,5 @@ describe('ViewStore cleaning behaviour', () => {
 
     const pageViews = getPageViews()
     expect(pageViews).toHaveLength(6);
-    expect(pageViews[0].ts).toEqual(Math.round(newerDate / 1000))
   });
 });

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -226,7 +226,6 @@ describe('Test look back edkt run', () => {
       pageFeatures: lookBackPageFeature,
       audienceDefinitions: [lookBackInfinityAudience],
       omitGdprConsent: true,
-      featureMaxAge: Infinity,
     });
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -226,6 +226,7 @@ describe('Test look back edkt run', () => {
       pageFeatures: lookBackPageFeature,
       audienceDefinitions: [lookBackInfinityAudience],
       omitGdprConsent: true,
+      featureMaxAge: Infinity,
     });
 
     const edktMatchedAudiences = edkt.getMatchedAudiences();


### PR DESCRIPTION
# Summary

Closes https://github.com/AirGrid/rmap/issues/289

This issue adds a mechanism to remove old and unneeded features from the user's local storage.

Features are added to the user's local storage as they view pages with our SDK installed.
There is no need to bloat storage with ancient features.

## Details

The user will configure the deletion logic by setting the configuration parameters on the `edkt.run` method call.
The `edkt.run` [Config](https://github.com/AirGrid/edgekit/compare/feature/delete-unused-features?expand=1#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R18-R19) was extended to take `featuresMaxAge` and `featuresStorageSize` parameters.
Currently, `featuresMaxAge` and `featuresStorageSize` defaults to Infinity.

There are two values which decide if a page view is to be deleted:

- its age;
- the total number of page views;

What we want to achieve is the following:

- delete all page views over `x` days old;
- if remaining page views count is over `y` trim the oldest to make sure we have just `y`;

The trimming procedure will happen on `ViewStore` loading, on the change of a configuration (by calling `edkt.run` with updated parameters or by calling the setter functions on `ViewStore`), and on an insertion event.

## Possible improvements

- Better default parameters (needs change in some tests);
- Add hysteresis on the trimming procedure, so it is called less often;

--------------------------

## EDIT

It turns out that just the trimming by storage size configuration was implemented.

The edkt's `ViewStore` instance will default to 300 items storage size and drop out the remaining older items on the insert event.
It behaves much like a FIFO buffer.