### PR TITLE
Refactor of types in the library.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,23 +2,9 @@ import * as engine from './engine';
 import { viewStore, matchedAudienceStore } from './store';
 import { timeStampInSecs } from './utils';
 import { waitForConsent } from './gdpr';
-import {
-  PageFeatureResult,
-  MatchedAudience,
-  AudienceDefinition,
-  PageView,
-} from '../types';
+import { Edkt } from '../types';
 
-interface Config {
-  audienceDefinitions: AudienceDefinition[];
-  pageFeatures?: Record<string, PageFeatureResult>;
-  pageMetadata?: Record<string, string | number | boolean>;
-  vendorIds?: number[];
-  omitGdprConsent?: boolean;
-  featureStorageSize?: number;
-}
-
-const run = async (config: Config): Promise<void> => {
+const run: Edkt['run'] = async (config) => {
   const {
     vendorIds,
     pageFeatures,
@@ -67,15 +53,15 @@ const run = async (config: Config): Promise<void> => {
   matchedAudienceStore.setMatchedAudiences(matchedAudiences);
 };
 
-const getMatchedAudiences = (): MatchedAudience[] => {
+const getMatchedAudiences: Edkt['getMatchedAudiences'] = () => {
   return matchedAudienceStore.matchedAudiences;
 };
 
-const getCopyOfPageViews = (): PageView[] => {
+const getCopyOfPageViews: Edkt['getCopyOfPageViews'] = () => {
   return [...viewStore.pageViews];
 };
 
-export const edkt = {
+export const edkt: Edkt = {
   run,
   getMatchedAudiences,
   getCopyOfPageViews,

--- a/test/audienceCosineSim.test.ts
+++ b/test/audienceCosineSim.test.ts
@@ -19,7 +19,6 @@ const makeCosineSimAudience = (
   ttl: 2592000,
   definition,
   id: 'testid',
-  // name: 'cosineSimAudience',
   version: 1,
 });
 

--- a/test/audienceCosineSim.test.ts
+++ b/test/audienceCosineSim.test.ts
@@ -19,7 +19,7 @@ const makeCosineSimAudience = (
   ttl: 2592000,
   definition,
   id: 'testid',
-  name: 'cosineSimAudience',
+  // name: 'cosineSimAudience',
   version: 1,
 });
 

--- a/test/gdpr.test.ts
+++ b/test/gdpr.test.ts
@@ -90,7 +90,6 @@ const updateTCDataAfterDelay = (): Promise<[number, number]> => {
 
 const sportAudience: AudienceDefinition = {
   id: 'sport_id',
-  // name: 'Sport Audience',
   version: 1,
   ttl: 100,
   lookBack: 10,

--- a/test/gdpr.test.ts
+++ b/test/gdpr.test.ts
@@ -90,7 +90,7 @@ const updateTCDataAfterDelay = (): Promise<[number, number]> => {
 
 const sportAudience: AudienceDefinition = {
   id: 'sport_id',
-  name: 'Sport Audience',
+  // name: 'Sport Audience',
   version: 1,
   ttl: 100,
   lookBack: 10,

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -33,7 +33,7 @@ export const automotiveKeywords = [
 
 export const sportInterestAudience: AudienceDefinition = {
   id: 'iab-607',
-  name: 'Interest | Sport',
+  // name: 'Interest | Sport',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,
@@ -50,7 +50,7 @@ export const sportInterestAudience: AudienceDefinition = {
 
 export const travelInterestAudience: AudienceDefinition = {
   id: 'iab-719',
-  name: 'Interest | Travel',
+  // name: 'Interest | Travel',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,
@@ -67,7 +67,7 @@ export const travelInterestAudience: AudienceDefinition = {
 
 export const automotiveInterestAudience: AudienceDefinition = {
   id: 'iab-243',
-  name: 'Interest | Automotive',
+  // name: 'Interest | Automotive',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -33,7 +33,6 @@ export const automotiveKeywords = [
 
 export const sportInterestAudience: AudienceDefinition = {
   id: 'iab-607',
-  // name: 'Interest | Sport',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,
@@ -50,7 +49,6 @@ export const sportInterestAudience: AudienceDefinition = {
 
 export const travelInterestAudience: AudienceDefinition = {
   id: 'iab-719',
-  // name: 'Interest | Travel',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,
@@ -67,7 +65,6 @@ export const travelInterestAudience: AudienceDefinition = {
 
 export const automotiveInterestAudience: AudienceDefinition = {
   id: 'iab-243',
-  // name: 'Interest | Automotive',
   version: VERSION,
   ttl: TTL_IN_SECS,
   lookBack: LOOK_BACK_IN_SECS,

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -37,7 +37,6 @@ const TTL = 10;
 
 const sportAudience: AudienceDefinition = {
   id: 'sport_id',
-  // name: 'Sport Audience',
   version: 1,
   ttl: TTL,
   lookBack: 10,
@@ -54,7 +53,6 @@ const sportAudience: AudienceDefinition = {
 
 const misconfiguredSportAudience: AudienceDefinition = {
   id: 'sport_id',
-  // name: 'Sport Audience',
   version: 1,
   ttl: TTL,
   lookBack: 10,
@@ -74,7 +72,6 @@ const misconfiguredSportAudience: AudienceDefinition = {
 
 const lookBackInfinityAudience: AudienceDefinition = {
   id: 'look_back_infinity_id',
-  // name: 'Look Back Audience',
   version: 1,
   ttl: TTL,
   lookBack: 0,
@@ -91,7 +88,6 @@ const lookBackInfinityAudience: AudienceDefinition = {
 
 const lookBackAudience: AudienceDefinition = {
   id: 'look_back_id',
-  // name: 'Look Back Audience',
   version: 1,
   ttl: TTL,
   lookBack: 2,
@@ -108,7 +104,6 @@ const lookBackAudience: AudienceDefinition = {
 
 const topicModelAudience: AudienceDefinition = {
   id: 'topic_model_id',
-  // name: 'Look Back Audience',
   version: 1,
   ttl: 100,
   lookBack: 2,
@@ -339,7 +334,6 @@ describe('Topic model run', () => {
 describe('Topic model run with additional audience', () => {
   const topicModelAudience: AudienceDefinition = {
     id: 'iab-608',
-    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -359,7 +353,6 @@ describe('Topic model run with additional audience', () => {
 
   const keywordsAudience: AudienceDefinition = {
     id: 'iab-607',
-    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -447,7 +440,6 @@ describe('Topic model run with additional audience', () => {
 describe('Topic model run version mismatch', () => {
   const topicModelAudience: AudienceDefinition = {
     id: 'iab-608',
-    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -467,7 +459,6 @@ describe('Topic model run version mismatch', () => {
 
   const keywordsAudience: AudienceDefinition = {
     id: 'iab-607',
-    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -37,7 +37,7 @@ const TTL = 10;
 
 const sportAudience: AudienceDefinition = {
   id: 'sport_id',
-  name: 'Sport Audience',
+  // name: 'Sport Audience',
   version: 1,
   ttl: TTL,
   lookBack: 10,
@@ -54,7 +54,7 @@ const sportAudience: AudienceDefinition = {
 
 const misconfiguredSportAudience: AudienceDefinition = {
   id: 'sport_id',
-  name: 'Sport Audience',
+  // name: 'Sport Audience',
   version: 1,
   ttl: TTL,
   lookBack: 10,
@@ -74,7 +74,7 @@ const misconfiguredSportAudience: AudienceDefinition = {
 
 const lookBackInfinityAudience: AudienceDefinition = {
   id: 'look_back_infinity_id',
-  name: 'Look Back Audience',
+  // name: 'Look Back Audience',
   version: 1,
   ttl: TTL,
   lookBack: 0,
@@ -91,7 +91,7 @@ const lookBackInfinityAudience: AudienceDefinition = {
 
 const lookBackAudience: AudienceDefinition = {
   id: 'look_back_id',
-  name: 'Look Back Audience',
+  // name: 'Look Back Audience',
   version: 1,
   ttl: TTL,
   lookBack: 2,
@@ -108,7 +108,7 @@ const lookBackAudience: AudienceDefinition = {
 
 const topicModelAudience: AudienceDefinition = {
   id: 'topic_model_id',
-  name: 'Look Back Audience',
+  // name: 'Look Back Audience',
   version: 1,
   ttl: 100,
   lookBack: 2,
@@ -339,7 +339,7 @@ describe('Topic model run', () => {
 describe('Topic model run with additional audience', () => {
   const topicModelAudience: AudienceDefinition = {
     id: 'iab-608',
-    name: 'Interest | Sport',
+    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -359,7 +359,7 @@ describe('Topic model run with additional audience', () => {
 
   const keywordsAudience: AudienceDefinition = {
     id: 'iab-607',
-    name: 'Interest | Sport',
+    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -447,7 +447,7 @@ describe('Topic model run with additional audience', () => {
 describe('Topic model run version mismatch', () => {
   const topicModelAudience: AudienceDefinition = {
     id: 'iab-608',
-    name: 'Interest | Sport',
+    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,
@@ -467,7 +467,7 @@ describe('Topic model run version mismatch', () => {
 
   const keywordsAudience: AudienceDefinition = {
     id: 'iab-607',
-    name: 'Interest | Sport',
+    // name: 'Interest | Sport',
     version: 1,
     occurrences: 1,
     ttl: 1000,

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,7 +17,7 @@ export interface PageView {
 export type StringArrayQueryValue = Extract<PageFeatureValue, string[]>;
 
 export type VectorQueryValue = {
-  vector: number[];
+  vector: Extract<PageFeatureValue, number[]>;
   threshold: number;
 };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,29 +11,8 @@ export type PageFeatureResult = {
   value: PageFeatureValue;
 };
 
-// unused?
-export interface PageFeatureGetter {
-  name: string;
-  func: () => Promise<PageFeatureResult>;
-}
-
-// unused?
-export type PageFeature =
-  | {
-      name: string;
-      error: true;
-    }
-  | {
-      name: string;
-      error: false;
-      version: number;
-      value: PageFeatureValue;
-    };
-
 export interface PageView {
   ts: number;
-  target?: boolean;  // unused?
-  keyHash?: string;  // unused?
   features: Record<string, PageFeatureResult>;
 }
 
@@ -80,8 +59,6 @@ export type AudienceQueryDefinition = {
 export interface AudienceDefinition {
   id: string;
   version: number;
-  name?: string;  // unused?
-  cacheFor?: number;  // unused?
   ttl: number;
   lookBack: number;
   occurrences: number;
@@ -128,9 +105,6 @@ export interface MatchedAudience {
   matchedOnCurrentPageView: boolean;
 }
 
-// unused?
-export type AudienceState = 'live' | 'paused' | 'deleted';
-
 export interface CachedAudienceMetaData {
   cachedAt: number;
   audiences: AudienceMetaData[];
@@ -157,13 +131,7 @@ export enum StorageKeys {
 
 // Network interfaces
 
-export interface PingResponse {
-  gdprApplies?: boolean;
-}
-
 export interface TCData {
-  gdprApplies?: boolean;
-
   eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';
 
   cmpStatus: 'stub' | 'loading' | 'loaded' | 'error';

--- a/types/index.ts
+++ b/types/index.ts
@@ -118,8 +118,8 @@ export enum StorageKeys {
 
 // Gdpr consent interfaces
 
+// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata
 export interface TCData {
-  // TODO I've put this back since the tests strongly suggests this should be considered
   gdprApplies: boolean;
 
   eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';

--- a/types/index.ts
+++ b/types/index.ts
@@ -132,6 +132,10 @@ export enum StorageKeys {
 // Network interfaces
 
 export interface TCData {
+
+  // TODO I've put this back since the tests strongly suggests this should be considered
+  gdprApplies: boolean;
+
   eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';
 
   cmpStatus: 'stub' | 'loading' | 'loaded' | 'error';

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,11 +11,13 @@ export type PageFeatureResult = {
   value: PageFeatureValue;
 };
 
+// unused?
 export interface PageFeatureGetter {
   name: string;
   func: () => Promise<PageFeatureResult>;
 }
 
+// unused?
 export type PageFeature =
   | {
       name: string;
@@ -30,8 +32,8 @@ export type PageFeature =
 
 export interface PageView {
   ts: number;
-  target?: boolean;
-  keyHash?: string;
+  target?: boolean;  // unused?
+  keyHash?: string;  // unused?
   features: Record<string, PageFeatureResult>;
 }
 
@@ -44,6 +46,7 @@ export interface MatchedAudience {
   matchedOnCurrentPageView: boolean;
 }
 
+// unused?
 export type AudienceState = 'live' | 'paused' | 'deleted';
 
 export interface CachedAudienceMetaData {
@@ -97,8 +100,8 @@ export type AudienceQueryDefinition = {
 export interface AudienceDefinition {
   id: string;
   version: number;
-  name?: string;
-  cacheFor?: number;
+  name?: string;  // unused?
+  cacheFor?: number;  // unused?
   ttl: number;
   lookBack: number;
   occurrences: number;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,5 @@
 // #############################
-// Domain Entities Interfaces
+// Domain Model Interfaces
 // #############################
 
 // Page view interfaces
@@ -39,27 +39,7 @@ export interface PageView {
 
 // Audience definition interfaces
 
-export interface MatchedAudience {
-  id: string;
-  matchedAt: number;
-  expiresAt: number;
-  matchedOnCurrentPageView: boolean;
-}
-
-// unused?
-export type AudienceState = 'live' | 'paused' | 'deleted';
-
-export interface CachedAudienceMetaData {
-  cachedAt: number;
-  audiences: AudienceMetaData[];
-}
-
-export interface AudienceMetaData {
-  id: string;
-  version: number;
-}
-
-export type StringArrayQueryValue = string[];
+export type StringArrayQueryValue = Extract<PageFeatureValue, string[]>;
 
 export type VectorQueryValue = {
   vector: number[];
@@ -72,17 +52,17 @@ export enum QueryFilterComparisonType {
   ARRAY_INTERSECTS = 'arrayIntersects',
 }
 
-export interface ArrayIntersectsFilter {
+export type ArrayIntersectsFilter = {
   queryValue: StringArrayQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.ARRAY_INTERSECTS;
 }
 
-export interface VectorDistanceFilter {
+export type VectorDistanceFilter = {
   queryValue: VectorQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.VECTOR_DISTANCE;
 }
 
-export interface CosineSimilarityFilter {
+export type CosineSimilarityFilter = {
   queryValue: VectorQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY;
 }
@@ -108,6 +88,10 @@ export interface AudienceDefinition {
   definition: AudienceQueryDefinition[]
 }
 
+// #############################
+// Domain Services Interfaces
+// #############################
+
 // Engine internal interfaces
 
 export interface EngineConditionRule {
@@ -129,6 +113,32 @@ export interface EngineCondition<T extends AudienceDefinitionFilter> {
     queries: EngineConditionQuery<T>[];
   };
   rules: EngineConditionRule[];
+}
+
+// #############################
+// Application Services Interfaces
+// #############################
+
+// Audience cache interfaces
+
+export interface MatchedAudience {
+  id: string;
+  matchedAt: number;
+  expiresAt: number;
+  matchedOnCurrentPageView: boolean;
+}
+
+// unused?
+export type AudienceState = 'live' | 'paused' | 'deleted';
+
+export interface CachedAudienceMetaData {
+  cachedAt: number;
+  audiences: AudienceMetaData[];
+}
+
+export interface AudienceMetaData {
+  id: string;
+  version: number;
 }
 
 // #############################

--- a/types/index.ts
+++ b/types/index.ts
@@ -163,6 +163,17 @@ declare global {
 
 // Top level API interfaces
 
+interface Config {
+  audienceDefinitions: AudienceDefinition[];
+  pageFeatures?: Record<string, PageFeatureResult>;
+  pageMetadata?: Record<string, string | number | boolean>;
+  vendorIds?: number[];
+  omitGdprConsent?: boolean;
+  featureStorageSize?: number;
+}
+
 export interface Edkt {
-  run: () => Promise<void>;
+  run: (config: Config) => Promise<void>;
+  getMatchedAudiences: () => MatchedAudience[];
+  getCopyOfPageViews: () => PageView[];
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,7 +1,3 @@
-// #############################
-// Domain Model Interfaces
-// #############################
-
 // Page view interfaces
 
 export type PageFeatureValue = string[] | number[];
@@ -34,22 +30,22 @@ export enum QueryFilterComparisonType {
 export type ArrayIntersectsFilter = {
   queryValue: StringArrayQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.ARRAY_INTERSECTS;
-}
+};
 
 export type VectorDistanceFilter = {
   queryValue: VectorQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.VECTOR_DISTANCE;
-}
+};
 
 export type CosineSimilarityFilter = {
   queryValue: VectorQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY;
-}
+};
 
 export type AudienceDefinitionFilter =
   | VectorDistanceFilter
   | CosineSimilarityFilter
-  | ArrayIntersectsFilter
+  | ArrayIntersectsFilter;
 
 export type AudienceQueryDefinition = {
   featureVersion: number;
@@ -62,12 +58,8 @@ export interface AudienceDefinition {
   ttl: number;
   lookBack: number;
   occurrences: number;
-  definition: AudienceQueryDefinition[]
+  definition: AudienceQueryDefinition[];
 }
-
-// #############################
-// Domain Services Interfaces
-// #############################
 
 // Engine internal interfaces
 
@@ -81,8 +73,11 @@ export interface EngineConditionRule {
   };
 }
 
-export type EngineConditionQuery<T extends AudienceDefinitionFilter> =
-  Pick<AudienceQueryDefinition, 'featureVersion' | 'queryProperty'> & T
+export type EngineConditionQuery<T extends AudienceDefinitionFilter> = Pick<
+  AudienceQueryDefinition,
+  'featureVersion' | 'queryProperty'
+> &
+  T;
 
 export interface EngineCondition<T extends AudienceDefinitionFilter> {
   filter: {
@@ -91,10 +86,6 @@ export interface EngineCondition<T extends AudienceDefinitionFilter> {
   };
   rules: EngineConditionRule[];
 }
-
-// #############################
-// Application Services Interfaces
-// #############################
 
 // Audience cache interfaces
 
@@ -115,10 +106,6 @@ export interface AudienceMetaData {
   version: number;
 }
 
-// #############################
-// External Services (Infrastructure) Interfaces
-// #############################
-
 // Storage interfaces
 
 export enum StorageKeys {
@@ -132,7 +119,6 @@ export enum StorageKeys {
 // Network interfaces
 
 export interface TCData {
-
   // TODO I've put this back since the tests strongly suggests this should be considered
   gdprApplies: boolean;
 
@@ -174,10 +160,6 @@ declare global {
     ): void;
   }
 }
-
-// #############################
-// UI Interfaces
-// #############################
 
 // Top level API interfaces
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -116,7 +116,7 @@ export interface AudienceMetaData {
 }
 
 // #############################
-// Infrastructure Interfaces
+// External Services (Infrastructure) Interfaces
 // #############################
 
 // Storage interfaces

--- a/types/index.ts
+++ b/types/index.ts
@@ -116,7 +116,7 @@ export enum StorageKeys {
   CACHED_AUDIENCE_META_DATA = 'edkt_cached_audience_meta_data',
 }
 
-// Network interfaces
+// Gdpr consent interfaces
 
 export interface TCData {
   // TODO I've put this back since the tests strongly suggests this should be considered

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,18 +1,8 @@
-export interface Edkt {
-  run: () => Promise<void>;
-}
+// #############################
+// Domain Entities Interfaces
+// #############################
 
-// Storage Keys Enum
-
-export enum StorageKeys {
-  PAGE_VIEWS = 'edkt_page_views',
-  MATCHED_AUDIENCES = 'edkt_matched_audiences',
-  MATCHED_AUDIENCE_IDS = 'edkt_matched_audience_ids',
-  CACHED_AUDIENCES = 'edkt_cached_audiences',
-  CACHED_AUDIENCE_META_DATA = 'edkt_cached_audience_meta_data',
-}
-
-// Page Features
+// Page view interfaces
 
 export type PageFeatureValue = string[] | number[];
 
@@ -45,7 +35,7 @@ export interface PageView {
   features: Record<string, PageFeatureResult>;
 }
 
-// Audiences
+// Audience definition interfaces
 
 export interface MatchedAudience {
   id: string;
@@ -115,7 +105,7 @@ export interface AudienceDefinition {
   definition: AudienceQueryDefinition[]
 }
 
-// Engine
+// Engine internal interfaces
 
 export interface EngineConditionRule {
   reducer: {
@@ -137,6 +127,22 @@ export interface EngineCondition<T extends AudienceDefinitionFilter> {
   };
   rules: EngineConditionRule[];
 }
+
+// #############################
+// Infrastructure Interfaces
+// #############################
+
+// Storage interfaces
+
+export enum StorageKeys {
+  PAGE_VIEWS = 'edkt_page_views',
+  MATCHED_AUDIENCES = 'edkt_matched_audiences',
+  MATCHED_AUDIENCE_IDS = 'edkt_matched_audience_ids',
+  CACHED_AUDIENCES = 'edkt_cached_audiences',
+  CACHED_AUDIENCE_META_DATA = 'edkt_cached_audience_meta_data',
+}
+
+// Network interfaces
 
 export interface PingResponse {
   gdprApplies?: boolean;
@@ -182,4 +188,14 @@ declare global {
       listenerId: number
     ): void;
   }
+}
+
+// #############################
+// UI Interfaces
+// #############################
+
+// Top level API interfaces
+
+export interface Edkt {
+  run: () => Promise<void>;
 }


### PR DESCRIPTION
# Summary

Types should outline the API & contracts between the codebase. The naming should also be consistent.
There were some changes suggested on [rmap#310](https://github.com/AirGrid/rmap/issues/310) and [rmap#362](https://github.com/AirGrid/rmap/issues/362), and this PR tries to address these issues.

This will serve as a mental model that we can use to think about the type structure's naming and organization.

## Objectives

- Remove unused code for each layer;
- Improve naming convention;
- Move type definitions to their appropriated places;
- Reduce duplication throughout platform implementing a solid base which will be extended where it is needed;

## Outline

Currently, types are declared and used in different ways in each of our services.

## Open-Source Edgekit

That is the core around which our platform is built.

### Domain model

> The very centre of the Model, this layer can have dependencies only on itself. It represents the Entities of the Business and the Behaviour of these Entities.

There are two main domain entities here:


#### PageView

- entity carrying info about visit time and relevant page features

Its minimal form would be:

```typescript
interface PageView {
  ts: number;
  features: Record<string, PageFeatureResult>;
}

type PageFeatureResult = {
  version: number;
  value: PageFeatureValue;
};

type PageFeatureValue = string[] | number[];
```

#### AudienceDefinition

- entity carrying info about target features and conditions used to classify visitors between possible advertisement audiences

Its minimal form would be:

```typescript
interface AudienceDefinition {
  id: string;
  version: number;
  ttl: number;
  lookBack: number;
  occurrences: number;
  queryDefinition: AudienceQueryDefinition[]
}

type AudienceQueryDefinition = {
  featureVersion: number;
  queryProperty: string;
} & AudienceDefinitionFilter;

type AudienceDefinitionFilter =
  | VectorDistanceFilter
  | CosineSimilarityFilter
  | ArrayIntersectsFilter

type ArrayIntersectsFilter = {
  queryValue: StringArrayQueryValue;
  queryFilterType: QueryFilterType.ARRAY_INTERSECTS;
}

type VectorDistanceFilter = {
  queryValue: VectorQueryValue;
  queryFilterType: QueryFilterType.VECTOR_DISTANCE;
}

type CosineSimilarityFilter = {
  queryValue: VectorQueryValue;
  queryFilterType: QueryFilterType.COSINE_SIMILARITY;
}

enum QueryFilterType {
  VECTOR_DISTANCE = 'vectorDistance',
  COSINE_SIMILARITY = 'cosineSimilarity',
  ARRAY_INTERSECTS = 'arrayIntersects',
}

type StringArrayQueryValue = Extract<PageFeatureValue, string[]>;

type VectorQueryValue = {
  vector: Extract<PageFeatureValue, number[]>;
  threshold: number;
};
```

### Domain Services

> This layer contains the implementation of the behaviour contracts defined in the Model layer.

The main domain service here is the matching engine layer.
This service translates the audience domain objects into rules for searching for matching (`PageView`, `AudienceDefinition`) pairs.

Its minimal form would be:
```typescript
interface EngineConditionRule {
  reducer: {
    name: 'count';
  };
  matcher: {
    name: 'eq' | 'gt' | 'lt' | 'ge' | 'le';
    args: number;
  };
}

type EngineConditionQuery<T extends AudienceDefinitionFilter> =
  Pick<AudienceQueryDefinition, 'featureVersion' | 'queryProperty'> & T

interface EngineCondition<T extends AudienceDefinitionFilter> {
  filter: {
    any?: boolean;
    queries: EngineConditionQuery<T>[];
  };
  rules: EngineConditionRule[];
}
```

### Application Services

> This layer is the bridge between external infrastructure and the domain layers.

Here we have a caching service for Audience data.

Its minimal form looks like:
```typescript
interface MatchedAudience {
  id: string;
  matchedAt: number;
  expiresAt: number;
  matchedOnCurrentPageView: boolean;
}

interface CachedAudienceMetaData {
  cachedAt: number;
  audiences: AudienceMetaData[];
}

interface AudienceMetaData {
  id: string;
  version: number;
}
```

### External Services

> Databases, Messaging systems, Notification systems, User Interface, etc.

Here we have the types outlining the interface with localStorage, as well as networking with the consent and vendor data services and the top-level UI.

Here is the minimal outline:

_Storage_
```typescript
enum StorageKeys {
  PAGE_VIEWS = 'edkt_page_views',
  MATCHED_AUDIENCES = 'edkt_matched_audiences',
  MATCHED_AUDIENCE_IDS = 'edkt_matched_audience_ids',
  CACHED_AUDIENCES = 'edkt_cached_audiences',
  CACHED_AUDIENCE_META_DATA = 'edkt_cached_audience_meta_data',
}
```

_Gdpr Consent_
```typescript
interface TCData {
  gdprApplies: boolean;

  eventStatus: 'tcloaded' | 'cmpuishown' | 'useractioncomplete';

  cmpStatus: 'stub' | 'loading' | 'loaded' | 'error';

  /**
   * If this TCData is sent to the callback of addEventListener: number,
   * the unique ID assigned by the CMP to the listener function registered
   * via addEventListener.
   * Others: undefined.
   */
  listenerId?: number | undefined;

  vendor: {
    consents: { [vendorId: number]: boolean | undefined };
  };
}

interface ConsentStatus {
  eventStatus: 'tcloaded' | 'useractioncomplete' | 'cmpuishown';
  hasConsent: boolean;
}

declare global {
  interface Window {
    __tcfapi(
      command: 'addEventListener',
      version: number,
      cb: (tcData: TCData, success: boolean) => void
    ): void;

    __tcfapi(
      command: 'removeEventListener',
      version: number,
      cb: (success: boolean) => void,
      listenerId: number
    ): void;
  }
}
```

_UI_
```typescript

interface Config {
  audienceDefinitions: AudienceDefinition[];
  pageFeatures?: Record<string, PageFeatureResult>;
  pageMetadata?: Record<string, string | number | boolean>;
  vendorIds?: number[];
  omitGdprConsent?: boolean;
  featureStorageSize?: number;
}

export interface Edkt {
  run: (config: Config) => Promise<void>;
  getMatchedAudiences: () => MatchedAudience[];
  getCopyOfPageViews: () => PageView[];
}
```