### PR TITLE
Fix type module references

### DIFF
--- a/src/engine/evaluate.ts
+++ b/src/engine/evaluate.ts
@@ -1,11 +1,7 @@
 import * as reducers from './reducers';
 import * as matchers from './matchers';
 import { queryMatches } from './filters';
-import {
-  PageView,
-  EngineCondition,
-  AudienceDefinitionFilter,
-} from '../../types';
+import { PageView, EngineCondition, AudienceDefinitionFilter } from 'types';
 
 /* Filter the pageView array by matching queries
  * and evaluates if it matches the conditions
@@ -18,7 +14,7 @@ export const evaluateCondition = (
   const { filter, rules } = condition;
 
   // if no queries, do not match at all
-  if (pageViews.length == 0 || filter.queries.length === 0) {
+  if (pageViews.length === 0 || filter.queries.length === 0) {
     return false;
   }
 

--- a/src/engine/filters/conditions.ts
+++ b/src/engine/filters/conditions.ts
@@ -10,7 +10,7 @@ import {
   AudienceDefinitionFilter,
   EngineConditionQuery,
   PageFeatureResult,
-} from '../../../types';
+} from 'types';
 
 /* =======================================
  * matching conditions

--- a/src/engine/filters/guards.ts
+++ b/src/engine/filters/guards.ts
@@ -6,7 +6,7 @@ import {
   VectorDistanceFilter,
   VectorQueryValue,
   QueryFilterComparisonType,
-} from '../../../types';
+} from 'types';
 
 /* Type Guards */
 

--- a/src/engine/filters/index.ts
+++ b/src/engine/filters/index.ts
@@ -2,7 +2,7 @@ import {
   AudienceDefinitionFilter,
   EngineConditionQuery,
   PageFeatureResult,
-} from '../../../types';
+} from 'types';
 import {
   versionMatches,
   arrayIntersectsCondition,

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,10 +1,6 @@
 import { evaluateCondition } from './evaluate';
 import { translate } from './translate';
-import {
-  PageView,
-  EngineCondition,
-  AudienceDefinitionFilter,
-} from '../../types';
+import { PageView, EngineCondition, AudienceDefinitionFilter } from 'types';
 
 const check = (
   conditions: EngineCondition<AudienceDefinitionFilter>[],

--- a/src/engine/reducers.ts
+++ b/src/engine/reducers.ts
@@ -1,4 +1,4 @@
-import { PageView } from '../../types';
+import { PageView } from 'types';
 
 export const count = () => (pageViews: PageView[]): number => pageViews.length;
 

--- a/src/engine/translate.ts
+++ b/src/engine/translate.ts
@@ -2,7 +2,7 @@ import {
   AudienceDefinition,
   EngineCondition,
   AudienceDefinitionFilter,
-} from '../../types';
+} from 'types';
 
 /*
  * Audience to Engine translation

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -1,4 +1,4 @@
-import { TCData, ConsentStatus } from '../../types';
+import { TCData, ConsentStatus } from 'types';
 import { timeout } from '../utils';
 
 export const waitForTcfApiTimeout = 10 * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as engine from './engine';
 import { viewStore, matchedAudienceStore } from './store';
 import { timeStampInSecs } from './utils';
 import { waitForConsent } from './gdpr';
-import { Edkt } from '../types';
+import { Edkt } from 'types';
 
 const run: Edkt['run'] = async (config) => {
   const {
@@ -69,4 +69,4 @@ export const edkt: Edkt = {
 
 export * from './store';
 export * from './gdpr';
-export * from '../types';
+export * from 'types';

--- a/src/store/cachedAudiences.ts
+++ b/src/store/cachedAudiences.ts
@@ -1,8 +1,4 @@
-import {
-  StorageKeys,
-  AudienceDefinition,
-  CachedAudienceMetaData,
-} from '../../types';
+import { StorageKeys, AudienceDefinition, CachedAudienceMetaData } from 'types';
 import { storage, timeStampInSecs } from '../utils';
 
 class CachedAudienceStore {

--- a/src/store/matchedAudiences.ts
+++ b/src/store/matchedAudiences.ts
@@ -1,5 +1,5 @@
 import { storage, timeStampInSecs } from '../utils';
-import { StorageKeys, MatchedAudience } from '../../types';
+import { StorageKeys, MatchedAudience } from 'types';
 
 class MatchedAudienceStore {
   matchedAudiences: MatchedAudience[];

--- a/src/store/pageview.ts
+++ b/src/store/pageview.ts
@@ -1,5 +1,5 @@
 import { storage, timeStampInSecs } from '../utils';
-import { PageView, StorageKeys, PageFeatureResult } from '../../types';
+import { PageView, StorageKeys, PageFeatureResult } from 'types';
 
 const DEFAULT_MAX_FEATURES_SIZE = 300;
 

--- a/test/arrayIntersectsEngineCondition.test.ts
+++ b/test/arrayIntersectsEngineCondition.test.ts
@@ -4,7 +4,7 @@ import {
   QueryFilterComparisonType,
   ArrayIntersectsFilter,
   PageView,
-} from '../types';
+} from 'types';
 import { clearStore } from './helpers/localStorageSetup';
 
 const sports1xConditionGt: EngineCondition<ArrayIntersectsFilter> = {

--- a/test/audienceCache.test.ts
+++ b/test/audienceCache.test.ts
@@ -1,5 +1,5 @@
 import { cachedAudienceStore } from '../src/store';
-import { CachedAudienceMetaData } from '../types';
+import { CachedAudienceMetaData } from 'types';
 import {
   sportInterestAudience,
   travelInterestAudience,

--- a/test/audienceCosineSim.test.ts
+++ b/test/audienceCosineSim.test.ts
@@ -3,7 +3,7 @@ import {
   QueryFilterComparisonType,
   AudienceQueryDefinition,
   VectorQueryValue,
-} from '../types';
+} from 'types';
 import { edkt } from '../src';
 import {
   clearStore,

--- a/test/cosineSimilarityEngineCondition.test.ts
+++ b/test/cosineSimilarityEngineCondition.test.ts
@@ -4,7 +4,7 @@ import {
   QueryFilterComparisonType,
   CosineSimilarityFilter,
   PageView,
-} from '../types';
+} from 'types';
 import { clearStore } from './helpers/localStorageSetup';
 
 const cosineSimilarityCondition: EngineCondition<CosineSimilarityFilter> = {

--- a/test/gdpr.test.ts
+++ b/test/gdpr.test.ts
@@ -1,10 +1,6 @@
 import { edkt } from '../src';
 import { checkConsentStatus, waitForTcfApiTimeout } from '../src/gdpr';
-import {
-  TCData,
-  AudienceDefinition,
-  QueryFilterComparisonType,
-} from '../types';
+import { TCData, AudienceDefinition, QueryFilterComparisonType } from 'types';
 import { getPageViews, getMatchedAudiences } from './helpers/localStorageSetup';
 
 const airgridVendorId = 782;

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -1,4 +1,4 @@
-import { AudienceDefinition, QueryFilterComparisonType } from '../../types';
+import { AudienceDefinition, QueryFilterComparisonType } from 'types';
 
 const TTL_IN_SECS = 100;
 const LOOK_BACK_IN_SECS = 100;

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -5,7 +5,7 @@ import {
   PageView,
   VectorQueryValue,
   AudienceQueryDefinition,
-} from '../../types';
+} from 'types';
 
 export const makeQuery = <T extends AudienceQueryDefinition>(
   queryValue: VectorQueryValue,

--- a/test/helpers/localStorageSetup.ts
+++ b/test/helpers/localStorageSetup.ts
@@ -3,7 +3,7 @@ import {
   AudienceDefinition,
   CachedAudienceMetaData,
   MatchedAudience,
-} from '../../types';
+} from 'types';
 import { viewStore, matchedAudienceStore } from '../../src/store';
 
 export const pageViewCreator = (

--- a/test/multipleQueriesEngineCondition.test.ts
+++ b/test/multipleQueriesEngineCondition.test.ts
@@ -4,7 +4,7 @@ import {
   makeQuery,
   makePageView,
 } from './helpers/engineConditions';
-import { QueryFilterComparisonType } from '../types';
+import { QueryFilterComparisonType } from 'types';
 
 const multipleOrthogonalQueriesCondition = makeEngineCondition(
   [

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,9 +1,5 @@
 import { edkt } from '../src';
-import {
-  AudienceDefinition,
-  PageView,
-  QueryFilterComparisonType,
-} from '../types';
+import { AudienceDefinition, PageView, QueryFilterComparisonType } from 'types';
 import { timeStampInSecs } from '../src/utils';
 import { viewStore, matchedAudienceStore } from '../src/store';
 import {

--- a/test/vectorDistanceEngineCondition.test.ts
+++ b/test/vectorDistanceEngineCondition.test.ts
@@ -4,7 +4,7 @@ import {
   QueryFilterComparisonType,
   VectorDistanceFilter,
   PageView,
-} from '../types';
+} from 'types';
 import { clearStore } from './helpers/localStorageSetup';
 
 const vectorCondition: EngineCondition<VectorDistanceFilter> = {


### PR DESCRIPTION
# Summary

This PR changes type module references from relative to absolute path.
Also, it fixes a == comparator that was laying around.

(I believe) It fixes the related problem with the platform CI pipeline not being able to import types on the build phase.