### PR TITLE
Remove ArrayIntersects and VectorDistance code paths and types + minor improvements

### DIFF
--- a/src/engine/filters/conditions.ts
+++ b/src/engine/filters/conditions.ts
@@ -1,9 +1,6 @@
 import { dotProduct, cosineSimilarity, sigmoid } from './math';
 import {
-  isStringArray,
   isNumberArray,
-  isArrayIntersectsFilterType,
-  isVectorDistanceFilterType,
   isCosineSimilarityFilterType,
   isLogisticRegressionFilterType,
 } from './guards';
@@ -11,37 +8,17 @@ import {
   AudienceDefinitionFilter,
   EngineConditionQuery,
   PageFeatureResult,
-  StringArrayQueryValue,
-  VectorQueryValue,
+  CosineSimilarityQueryValue,
   LogisticRegressionQueryValue,
 } from '../../../types';
-
-/* =======================================
- * matching conditions
- * =======================================
- */
 
 export const versionMatches = (
   query: EngineConditionQuery<AudienceDefinitionFilter>,
   pageFeatures: PageFeatureResult
 ): boolean => pageFeatures.version === query.featureVersion;
 
-const stringArrayIntersects = (
-  queryValue: StringArrayQueryValue,
-  pageFeatures: string[]
-): boolean =>
-  pageFeatures.some((feature) => queryValue.indexOf(feature) !== -1);
-
-const isVectorDistanceGreatherThanThreshold = (
-  queryValue: VectorQueryValue,
-  pageFeatures: number[]
-): boolean =>
-  pageFeatures.length === queryValue.vector.length
-    ? dotProduct(pageFeatures, queryValue.vector) > queryValue.threshold
-    : false;
-
 const isCosineSimilarityGreatherThanThreshold = (
-  queryValue: VectorQueryValue,
+  queryValue: CosineSimilarityQueryValue,
   pageFeatures: number[]
 ): boolean =>
   pageFeatures.length === queryValue.vector.length
@@ -57,32 +34,6 @@ const isLogisticRegressionGreatherThanThreshold = (
       queryValue.threshold
     : false;
 
-/* =======================================
- * string array conditions
- * =======================================
- */
-
-export const arrayIntersectsCondition = (
-  query: EngineConditionQuery<AudienceDefinitionFilter>,
-  pageFeatures: PageFeatureResult
-): boolean =>
-  isArrayIntersectsFilterType(query) &&
-  isStringArray(pageFeatures.value) &&
-  stringArrayIntersects(query.queryValue, pageFeatures.value);
-
-/* =======================================
- * vector array conditions
- * =======================================
- */
-
-export const vectorDistanceCondition = (
-  query: EngineConditionQuery<AudienceDefinitionFilter>,
-  pageFeatures: PageFeatureResult
-): boolean =>
-  isVectorDistanceFilterType(query) &&
-  isNumberArray(pageFeatures.value) &&
-  isVectorDistanceGreatherThanThreshold(query.queryValue, pageFeatures.value);
-
 export const cosineSimilarityCondition = (
   query: EngineConditionQuery<AudienceDefinitionFilter>,
   pageFeatures: PageFeatureResult
@@ -90,11 +41,6 @@ export const cosineSimilarityCondition = (
   isCosineSimilarityFilterType(query) &&
   isNumberArray(pageFeatures.value) &&
   isCosineSimilarityGreatherThanThreshold(query.queryValue, pageFeatures.value);
-
-/* =======================================
- * logReg array condition
- * =======================================
- */
 
 export const logisticRegressionCondition = (
   query: EngineConditionQuery<AudienceDefinitionFilter>,

--- a/src/engine/filters/guards.ts
+++ b/src/engine/filters/guards.ts
@@ -1,11 +1,9 @@
 import {
-  ArrayIntersectsFilter,
   AudienceDefinitionFilter,
   CosineSimilarityFilter,
   LogisticRegressionFilter,
   EngineConditionQuery,
-  VectorDistanceFilter,
-  VectorQueryValue,
+  CosineSimilarityQueryValue,
   LogisticRegressionQueryValue,
   QueryFilterComparisonType,
 } from '../../../types';
@@ -13,17 +11,13 @@ import {
 /* Type Guards */
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export const isStringArray = (value: any): value is string[] =>
-  value instanceof Array && value.every((item) => typeof item === 'string');
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 export const isNumberArray = (value: any): value is number[] =>
   value instanceof Array && value.every((item) => typeof item === 'number');
 
-export const isVectorQueryValue = (
+export const isCosineSimilarityQueryValue = (
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   value: any
-): value is VectorQueryValue =>
+): value is CosineSimilarityQueryValue =>
   isNumberArray(value.vector) && typeof value.threshold === 'number';
 
 export const isLogRegQueryValue = (
@@ -34,33 +28,13 @@ export const isLogRegQueryValue = (
   typeof value.threshold === 'number' &&
   typeof value.bias === 'number';
 
-export const isArrayIntersectsFilterType = (
-  query: EngineConditionQuery<AudienceDefinitionFilter>
-): query is EngineConditionQuery<ArrayIntersectsFilter> => {
-  return (
-    query.queryFilterComparisonType ===
-      QueryFilterComparisonType.ARRAY_INTERSECTS &&
-    isStringArray(query.queryValue)
-  );
-};
-
-export const isVectorDistanceFilterType = (
-  query: EngineConditionQuery<AudienceDefinitionFilter>
-): query is EngineConditionQuery<VectorDistanceFilter> => {
-  return (
-    query.queryFilterComparisonType ===
-      QueryFilterComparisonType.VECTOR_DISTANCE &&
-    isVectorQueryValue(query.queryValue)
-  );
-};
-
 export const isCosineSimilarityFilterType = (
   query: EngineConditionQuery<AudienceDefinitionFilter>
 ): query is EngineConditionQuery<CosineSimilarityFilter> => {
   return (
     query.queryFilterComparisonType ===
       QueryFilterComparisonType.COSINE_SIMILARITY &&
-    isVectorQueryValue(query.queryValue)
+    isCosineSimilarityQueryValue(query.queryValue)
   );
 };
 

--- a/src/engine/filters/index.ts
+++ b/src/engine/filters/index.ts
@@ -5,8 +5,6 @@ import {
 } from '../../../types';
 import {
   versionMatches,
-  arrayIntersectsCondition,
-  vectorDistanceCondition,
   cosineSimilarityCondition,
   logisticRegressionCondition,
 } from './conditions';
@@ -21,8 +19,6 @@ export const queryMatches = (
 
   // matches if any of the conditions are satisfied
   return [
-    arrayIntersectsCondition,
-    vectorDistanceCondition,
     cosineSimilarityCondition,
     logisticRegressionCondition,
   ].some((match) => match(query, pageFeatures));

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -10,13 +10,9 @@ import {
 } from '../../types';
 
 const check = (
-  conditions: EngineCondition<AudienceDefinitionFilter>[],
-  pageViews: PageView[],
-  any = false
-): boolean =>
-  conditions[any ? 'some' : 'every']((condition) =>
-    evaluateCondition(condition, pageViews)
-  );
+  condition: EngineCondition<AudienceDefinitionFilter>,
+  pageViews: PageView[]
+): boolean => evaluateCondition(condition, pageViews);
 
 const getMatchingAudiences = (
   audienceDefinitions: AudienceDefinition[],
@@ -25,12 +21,12 @@ const getMatchingAudiences = (
   const currentTS = timeStampInSecs();
 
   return audienceDefinitions.reduce((acc, audience) => {
-    const conditions = translate(audience);
+    const condition = translate(audience);
     const pageViewsWithinLookBack = pageViews.filter(
       (pageView) =>
         audience.lookBack === 0 || pageView.ts > currentTS - audience.lookBack
     );
-    return check(conditions, pageViewsWithinLookBack)
+    return check(condition, pageViewsWithinLookBack)
       ? [
           ...acc,
           {

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,18 +1,7 @@
 import { evaluateCondition } from './evaluate';
 import { timeStampInSecs } from '../utils';
 import { translate } from './translate';
-import {
-  PageView,
-  EngineCondition,
-  AudienceDefinition,
-  AudienceDefinitionFilter,
-  MatchedAudience,
-} from '../../types';
-
-const check = (
-  condition: EngineCondition<AudienceDefinitionFilter>,
-  pageViews: PageView[]
-): boolean => evaluateCondition(condition, pageViews);
+import { PageView, AudienceDefinition, MatchedAudience } from '../../types';
 
 const getMatchingAudiences = (
   audienceDefinitions: AudienceDefinition[],
@@ -26,7 +15,7 @@ const getMatchingAudiences = (
       (pageView) =>
         audience.lookBack === 0 || pageView.ts > currentTS - audience.lookBack
     );
-    return check(condition, pageViewsWithinLookBack)
+    return evaluateCondition(condition, pageViewsWithinLookBack)
       ? [
           ...acc,
           {
@@ -41,4 +30,4 @@ const getMatchingAudiences = (
   }, [] as MatchedAudience[]);
 };
 
-export { translate, check, getMatchingAudiences };
+export { translate, evaluateCondition, getMatchingAudiences };

--- a/src/engine/translate.ts
+++ b/src/engine/translate.ts
@@ -12,24 +12,22 @@ import {
  */
 export const translate = (
   audienceDefinition: AudienceDefinition
-): EngineCondition<AudienceDefinitionFilter>[] => {
-  return [
-    {
-      filter: {
-        any: false,
-        queries: audienceDefinition.definition,
-      },
-      rules: [
-        {
-          reducer: {
-            name: 'count',
-          },
-          matcher: {
-            name: 'gt',
-            args: audienceDefinition.occurrences,
-          },
-        },
-      ],
+): EngineCondition<AudienceDefinitionFilter> => {
+  return {
+    filter: {
+      any: false,
+      queries: audienceDefinition.definition,
     },
-  ];
+    rules: [
+      {
+        reducer: {
+          name: 'count',
+        },
+        matcher: {
+          name: 'gt',
+          args: audienceDefinition.occurrences,
+        },
+      },
+    ],
+  };
 };

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -2,7 +2,7 @@ import {
   AudienceDefinition,
   QueryFilterComparisonType,
   AudienceQueryDefinition,
-  VectorQueryValue,
+  CosineSimilarityQueryValue,
   LogisticRegressionQueryValue,
 } from '../../types';
 
@@ -34,7 +34,7 @@ export const makeCosineSimilarityQuery = ({
   queryValue,
   ...partialAudienceQueryDefinition
 }: {
-  queryValue: VectorQueryValue;
+  queryValue: CosineSimilarityQueryValue;
 } & PartialAudienceQueryDefinition): AudienceQueryDefinition => ({
   featureVersion: 1,
   queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY,

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -55,23 +55,3 @@ export const makeDocVectorPageView = (
     },
   },
 });
-
-export const makeSportsPageView = (ts: number): PageView => ({
-  ts,
-  features: {
-    keywords: {
-      version: 1,
-      value: ['sport', 'football'],
-    },
-  },
-});
-
-export const makeTestPageView = (ts: number): PageView => ({
-  ts,
-  features: {
-    keywords: {
-      version: 1,
-      value: ['test', 'test2'],
-    },
-  },
-});

--- a/test/unit/engine/cosineSimilarityCondition.test.ts
+++ b/test/unit/engine/cosineSimilarityCondition.test.ts
@@ -18,22 +18,20 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     ]);
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const conditions = [cosineSimilarityCondition];
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 1)];
 
-      const result = check(conditions, pageViews);
+      const result = check(cosineSimilarityCondition, pageViews);
 
       expect(result).toEqual(true);
     });
 
     it('does not match the page view if similarity is not above threshold', () => {
-      const conditions = [cosineSimilarityCondition];
       const pageViews = [
         makeTopicDistPageView([0.2, 0.8, 0.1], 1, 100),
         makeTopicDistPageView([0.3, 0.8, 0.1], 1, 101),
       ];
 
-      const result = check(conditions, pageViews);
+      const result = check(cosineSimilarityCondition, pageViews);
 
       expect(result).toEqual(false);
     });
@@ -52,19 +50,17 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     ]);
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
-      const conditions = [cosineSimilarityCondition];
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 2, 100)];
 
-      const result = check(conditions, pageViews);
+      const result = check(cosineSimilarityCondition, pageViews);
 
       expect(result).toBe(true);
     });
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
-      const conditions = [cosineSimilarityCondition];
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 1, 100)];
 
-      const result = check(conditions, pageViews);
+      const result = check(cosineSimilarityCondition, pageViews);
 
       expect(result).toBe(false);
     });

--- a/test/unit/engine/cosineSimilarityCondition.test.ts
+++ b/test/unit/engine/cosineSimilarityCondition.test.ts
@@ -1,4 +1,4 @@
-import { check } from '../../../src/engine';
+import { evaluateCondition } from '../../../src/engine';
 import {
   makeEngineCondition,
   makeTopicDistPageView,
@@ -20,7 +20,7 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     it('does match the page view if vector similarity is above threshold', () => {
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 1)];
 
-      const result = check(cosineSimilarityCondition, pageViews);
+      const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
       expect(result).toEqual(true);
     });
@@ -31,7 +31,7 @@ describe('engine matching behaviour for cosine similarity condition', () => {
         makeTopicDistPageView([0.3, 0.8, 0.1], 1, 101),
       ];
 
-      const result = check(cosineSimilarityCondition, pageViews);
+      const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
       expect(result).toEqual(false);
     });
@@ -52,7 +52,7 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 2, 100)];
 
-      const result = check(cosineSimilarityCondition, pageViews);
+      const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
       expect(result).toBe(true);
     });
@@ -60,7 +60,7 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
       const pageViews = [makeTopicDistPageView([0.4, 0.8, 0.3], 1, 100)];
 
-      const result = check(cosineSimilarityCondition, pageViews);
+      const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
       expect(result).toBe(false);
     });

--- a/test/unit/engine/logisticRegressionCondition.test.ts
+++ b/test/unit/engine/logisticRegressionCondition.test.ts
@@ -1,4 +1,4 @@
-import { check } from '../../../src/engine';
+import { evaluateCondition } from '../../../src/engine';
 import {
   makeEngineCondition,
   makeDocVectorPageView,
@@ -21,7 +21,7 @@ describe('engine matching behaviour for logistic regression condition', () => {
     it('does match the page view if vector similarity is above threshold', () => {
       const pageViews = [makeDocVectorPageView([1, 1, 1], 1)];
 
-      const result = check(versionOneCondition, pageViews);
+      const result = evaluateCondition(versionOneCondition, pageViews);
 
       expect(result).toEqual(true);
     });
@@ -32,7 +32,7 @@ describe('engine matching behaviour for logistic regression condition', () => {
         makeDocVectorPageView([0.3, 0.8, 0.1], 1, 101),
       ];
 
-      const result = check(versionOneCondition, pageViews);
+      const result = evaluateCondition(versionOneCondition, pageViews);
 
       expect(result).toEqual(false);
     });
@@ -54,7 +54,7 @@ describe('engine matching behaviour for logistic regression condition', () => {
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
       const pageViews = [makeDocVectorPageView([1, 1, 1], 2, 100)];
 
-      const result = check(versionTwoCondition, pageViews);
+      const result = evaluateCondition(versionTwoCondition, pageViews);
 
       expect(result).toBe(true);
     });
@@ -62,7 +62,7 @@ describe('engine matching behaviour for logistic regression condition', () => {
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
       const pageViews = [makeDocVectorPageView([0.4, 0.8, 0.3], 1, 100)];
 
-      const result = check(versionTwoCondition, pageViews);
+      const result = evaluateCondition(versionTwoCondition, pageViews);
 
       expect(result).toBe(false);
     });

--- a/test/unit/engine/logisticRegressionCondition.test.ts
+++ b/test/unit/engine/logisticRegressionCondition.test.ts
@@ -7,7 +7,7 @@ import { makeLogisticRegressionQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for logistic regression condition', () => {
   describe('logReg condition with same condition/pageView version', () => {
-    const condition = makeEngineCondition([
+    const versionOneCondition = makeEngineCondition([
       makeLogisticRegressionQuery({
         queryValue: {
           vector: [1, 1, 1],
@@ -19,22 +19,20 @@ describe('engine matching behaviour for logistic regression condition', () => {
     ]);
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const conditions = [condition];
       const pageViews = [makeDocVectorPageView([1, 1, 1], 1)];
 
-      const result = check(conditions, pageViews);
+      const result = check(versionOneCondition, pageViews);
 
       expect(result).toEqual(true);
     });
 
     it('does not match the page view if similarity is not above threshold', () => {
-      const conditions = [condition];
       const pageViews = [
         makeDocVectorPageView([0.2, 0.8, 0.1], 1, 100),
         makeDocVectorPageView([0.3, 0.8, 0.1], 1, 101),
       ];
 
-      const result = check(conditions, pageViews);
+      const result = check(versionOneCondition, pageViews);
 
       expect(result).toEqual(false);
     });
@@ -42,7 +40,7 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
   describe('logRef condition with a bumped featureVersion', () => {
     // Vector condition with a bumped featureVersion
-    const logisticRegressionCondition = makeEngineCondition([
+    const versionTwoCondition = makeEngineCondition([
       makeLogisticRegressionQuery({
         queryValue: {
           vector: [1, 1, 1],
@@ -54,19 +52,17 @@ describe('engine matching behaviour for logistic regression condition', () => {
     ]);
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
-      const conditions = [logisticRegressionCondition];
       const pageViews = [makeDocVectorPageView([1, 1, 1], 2, 100)];
 
-      const result = check(conditions, pageViews);
+      const result = check(versionTwoCondition, pageViews);
 
       expect(result).toBe(true);
     });
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
-      const conditions = [logisticRegressionCondition];
       const pageViews = [makeDocVectorPageView([0.4, 0.8, 0.3], 1, 100)];
 
-      const result = check(conditions, pageViews);
+      const result = check(versionTwoCondition, pageViews);
 
       expect(result).toBe(false);
     });

--- a/test/unit/engine/multipleQueriesCondition.test.ts
+++ b/test/unit/engine/multipleQueriesCondition.test.ts
@@ -27,43 +27,38 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   );
 
   it('does match for condition above threshold on fisrt query object', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
     const pageViews = [makeTopicDistPageView([1, 0, 0], 1)];
 
-    const result = check(conditions, pageViews);
+    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
 
     expect(result).toEqual(true);
   });
 
   it('does match for condition above threshold on second query object', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
     const pageViews = [makeTopicDistPageView([0, 1, 0], 1)];
 
-    const result = check(conditions, pageViews);
+    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
 
     expect(result).toEqual(true);
   });
 
   it('does not match for condition below threshold on every query object', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
     const pageViews = [makeTopicDistPageView([0, 0, 1], 1)];
 
-    const result = check(conditions, pageViews);
+    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
 
     expect(result).toEqual(false);
   });
 
   it('does match for condition above threshold on at least one (pageView, condition) pair', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
-
     expect(
-      check(conditions, [
+      check(multipleNonOverlapingQueriesCondition, [
         makeTopicDistPageView([1, 0, 0], 1),
         makeTopicDistPageView([0, 0, 1], 1),
       ])
     ).toEqual(true);
     expect(
-      check(conditions, [
+      check(multipleNonOverlapingQueriesCondition, [
         makeTopicDistPageView([0, 1, 0], 1),
         makeTopicDistPageView([0, 0, 1], 1),
       ])
@@ -71,7 +66,6 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   });
 
   it('does not match for different (condition, pageView) versions attributes', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
     const pageViews = [
       makeTopicDistPageView([1, 0, 0], 2),
       makeTopicDistPageView([0, 1, 0], 2),
@@ -79,13 +73,12 @@ describe('engine matching behaviour for multiple engine condition values', () =>
       makeTopicDistPageView([1, 1, 1], 2),
     ];
 
-    const result = check(conditions, pageViews);
+    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
 
     expect(result).toEqual(false);
   });
 
   it('does match for mixed versions/conditions with enough evidence', () => {
-    const conditions = [multipleNonOverlapingQueriesCondition];
     const pageViews = [
       makeTopicDistPageView([1, 0, 0], 1),
       makeTopicDistPageView([0, 1, 0], 2),
@@ -93,7 +86,7 @@ describe('engine matching behaviour for multiple engine condition values', () =>
       makeTopicDistPageView([1, 1, 1], 2),
     ];
 
-    const result = check(conditions, pageViews);
+    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
 
     expect(result).toEqual(true);
   });

--- a/test/unit/engine/multipleQueriesCondition.test.ts
+++ b/test/unit/engine/multipleQueriesCondition.test.ts
@@ -1,4 +1,4 @@
-import { check } from '../../../src/engine';
+import { evaluateCondition } from '../../../src/engine';
 import {
   makeEngineCondition,
   makeTopicDistPageView,
@@ -29,7 +29,10 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   it('does match for condition above threshold on fisrt query object', () => {
     const pageViews = [makeTopicDistPageView([1, 0, 0], 1)];
 
-    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
+    const result = evaluateCondition(
+      multipleNonOverlapingQueriesCondition,
+      pageViews
+    );
 
     expect(result).toEqual(true);
   });
@@ -37,7 +40,10 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   it('does match for condition above threshold on second query object', () => {
     const pageViews = [makeTopicDistPageView([0, 1, 0], 1)];
 
-    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
+    const result = evaluateCondition(
+      multipleNonOverlapingQueriesCondition,
+      pageViews
+    );
 
     expect(result).toEqual(true);
   });
@@ -45,20 +51,23 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   it('does not match for condition below threshold on every query object', () => {
     const pageViews = [makeTopicDistPageView([0, 0, 1], 1)];
 
-    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
+    const result = evaluateCondition(
+      multipleNonOverlapingQueriesCondition,
+      pageViews
+    );
 
     expect(result).toEqual(false);
   });
 
   it('does match for condition above threshold on at least one (pageView, condition) pair', () => {
     expect(
-      check(multipleNonOverlapingQueriesCondition, [
+      evaluateCondition(multipleNonOverlapingQueriesCondition, [
         makeTopicDistPageView([1, 0, 0], 1),
         makeTopicDistPageView([0, 0, 1], 1),
       ])
     ).toEqual(true);
     expect(
-      check(multipleNonOverlapingQueriesCondition, [
+      evaluateCondition(multipleNonOverlapingQueriesCondition, [
         makeTopicDistPageView([0, 1, 0], 1),
         makeTopicDistPageView([0, 0, 1], 1),
       ])
@@ -73,7 +82,10 @@ describe('engine matching behaviour for multiple engine condition values', () =>
       makeTopicDistPageView([1, 1, 1], 2),
     ];
 
-    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
+    const result = evaluateCondition(
+      multipleNonOverlapingQueriesCondition,
+      pageViews
+    );
 
     expect(result).toEqual(false);
   });
@@ -86,7 +98,10 @@ describe('engine matching behaviour for multiple engine condition values', () =>
       makeTopicDistPageView([1, 1, 1], 2),
     ];
 
-    const result = check(multipleNonOverlapingQueriesCondition, pageViews);
+    const result = evaluateCondition(
+      multipleNonOverlapingQueriesCondition,
+      pageViews
+    );
 
     expect(result).toEqual(true);
   });

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,10 +1,8 @@
 // Page view interfaces
 
-export type PageFeatureValue = string[] | number[];
-
 export type PageFeatureResult = {
   version: number;
-  value: PageFeatureValue;
+  value: number[];
 };
 
 export interface PageView {
@@ -14,38 +12,24 @@ export interface PageView {
 
 // Audience definition interfaces
 
-export type StringArrayQueryValue = Extract<PageFeatureValue, string[]>;
-
-export type VectorQueryValue = {
-  vector: Extract<PageFeatureValue, number[]>;
+export type CosineSimilarityQueryValue = {
+  vector: PageFeatureResult['value'];
   threshold: number;
 };
 
 export type LogisticRegressionQueryValue = {
-  vector: Extract<PageFeatureValue, number[]>;
+  vector: PageFeatureResult['value'];
   bias: number;
   threshold: number;
 };
 
 export enum QueryFilterComparisonType {
-  VECTOR_DISTANCE = 'vectorDistance',
   COSINE_SIMILARITY = 'cosineSimilarity',
-  ARRAY_INTERSECTS = 'arrayIntersects',
   LOGISTIC_REGRESSION = 'logisticRegression',
 }
 
-export type ArrayIntersectsFilter = {
-  queryValue: StringArrayQueryValue;
-  queryFilterComparisonType: QueryFilterComparisonType.ARRAY_INTERSECTS;
-};
-
-export type VectorDistanceFilter = {
-  queryValue: VectorQueryValue;
-  queryFilterComparisonType: QueryFilterComparisonType.VECTOR_DISTANCE;
-};
-
 export type CosineSimilarityFilter = {
-  queryValue: VectorQueryValue;
+  queryValue: CosineSimilarityQueryValue;
   queryFilterComparisonType: QueryFilterComparisonType.COSINE_SIMILARITY;
 };
 
@@ -55,9 +39,7 @@ export type LogisticRegressionFilter = {
 };
 
 export type AudienceDefinitionFilter =
-  | VectorDistanceFilter
   | CosineSimilarityFilter
-  | ArrayIntersectsFilter
   | LogisticRegressionFilter;
 
 export type AudienceQueryDefinition = {


### PR DESCRIPTION
# Summary

This removes unused matcher code paths from edgekit library.
It also adds minor improvements to the engine `translate` and `check` methods.

Closes https://github.com/AirGrid/edgekit/issues/140