### PR TITLE
Fix rematched audiences being refreshed every page view

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:unit:watch": "jest --config jest.unit.config.js --watch",
     "test:unit:coverage": "jest --coverage",
     "test:e2e": "npm run bundle && jest --config jest.e2e.config.js",
+    "test:clean": "jest --clearCache",
     "lint": "eslint src test --ext js,ts",
     "lint:fix": "eslint src test --ext js,ts --fix"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,12 @@ const run: Edkt['run'] = async (config) => {
 
   const pageViews = viewStore.getCopyOfPageViews();
 
+  // match only the new audiences
+  const definitionsToMatch = matchedAudienceStore.filterNewAudienceDefinitions(
+    audienceDefinitions
+  );
   const matchedAudiences = engine.getMatchingAudiences(
-    audienceDefinitions,
+    definitionsToMatch,
     pageViews
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ const run: Edkt['run'] = async (config) => {
     pageViews
   );
 
-  matchedAudienceStore.setMatchedAudiences(matchedAudiences);
+  matchedAudienceStore.updateMatchedAudiences(
+    matchedAudiences,
+    audienceDefinitions
+  );
 };
 
 export const edkt: Edkt = {

--- a/test/unit/store/matchedAudiences.test.ts
+++ b/test/unit/store/matchedAudiences.test.ts
@@ -4,10 +4,13 @@ import { clearStore } from '../../helpers/localStorage';
 import { MatchedAudience, AudienceDefinition } from '../../../types';
 
 describe('matchedAudienceStore set and load behaviour', () => {
-  const makeMatchedAudienceAndDefinition = (
-    id: string,
-    version: number
-  ): [MatchedAudience, AudienceDefinition] => {
+  const makeMatchedAudienceAndDefinition = ({
+    id,
+    version,
+  }: {
+    id: AudienceDefinition['id'];
+    version: AudienceDefinition['version'];
+  }): [MatchedAudience, AudienceDefinition] => {
     const currentTS = timeStampInSecs();
     return [
       {
@@ -30,32 +33,42 @@ describe('matchedAudienceStore set and load behaviour', () => {
 
   const matchedAudienceId = 'testId';
   const fixedAudienceId = 'fixedAudienceId';
+  const newlyMatchedAudienceId = 'totallyNewAudience';
 
+  // matchedAudiences and definitions
   const [
     matchedAudience,
     matchedAudienceDefinition,
-  ] = makeMatchedAudienceAndDefinition(matchedAudienceId, 1);
-  const [
-    fixedMatchedAudience,
-    fixedAudienceDefinition,
-  ] = makeMatchedAudienceAndDefinition(fixedAudienceId, 1);
-
+  ] = makeMatchedAudienceAndDefinition({
+    id: matchedAudienceId,
+    version: 1,
+  });
   const [
     _rematchedAudience,
     rematchedAudienceDefinition,
-  ] = makeMatchedAudienceAndDefinition(matchedAudienceId, 2);
+  ] = makeMatchedAudienceAndDefinition({ id: matchedAudienceId, version: 2 });
   const rematchedAudience = unsetMatchedOnCurrentPageViewFlag(
     _rematchedAudience
   );
-
+  const [
+    fixedMatchedAudience,
+    fixedAudienceDefinition,
+  ] = makeMatchedAudienceAndDefinition({ id: fixedAudienceId, version: 1 });
   const [
     newlyMatchedAudience,
     newlyMatchedAudienceDefinition,
-  ] = makeMatchedAudienceAndDefinition('totallyNewAudience', 1);
+  ] = makeMatchedAudienceAndDefinition({
+    id: newlyMatchedAudienceId,
+    version: 1,
+  });
 
+  // updated matchedAudiences (matchedOnCurrentPageView unset)
   const oldMatchedAudience = unsetMatchedOnCurrentPageViewFlag(matchedAudience);
   const oldFixedMatchedAudience = unsetMatchedOnCurrentPageViewFlag(
     fixedMatchedAudience
+  );
+  const oldRematchedAudience = unsetMatchedOnCurrentPageViewFlag(
+    rematchedAudience
   );
 
   beforeAll(clearStore);
@@ -108,10 +121,6 @@ describe('matchedAudienceStore set and load behaviour', () => {
         rematchedAudienceDefinition,
         fixedAudienceDefinition,
       ]
-    );
-
-    const oldRematchedAudience = unsetMatchedOnCurrentPageViewFlag(
-      rematchedAudience
     );
 
     const matchedAudiences = matchedAudienceStore.getMatchedAudiences();

--- a/test/unit/store/matchedAudiences.test.ts
+++ b/test/unit/store/matchedAudiences.test.ts
@@ -1,0 +1,123 @@
+import { matchedAudienceStore } from '../../../src/store/matchedAudiences';
+import { timeStampInSecs } from '../../../src/utils/index';
+import { clearStore } from '../../helpers/localStorage';
+import { MatchedAudience, AudienceDefinition } from '../../../types';
+
+describe('matchedAudienceStore set and load behaviour', () => {
+  const makeMatchedAudienceAndDefinition = (
+    id: string,
+    version: number
+  ): [MatchedAudience, AudienceDefinition] => {
+    const currentTS = timeStampInSecs();
+    return [
+      {
+        id,
+        version,
+        matchedAt: currentTS,
+        expiresAt: currentTS + 1000000000,
+        matchedOnCurrentPageView: true,
+      } as MatchedAudience,
+      { id, version } as AudienceDefinition,
+    ];
+  };
+
+  const unsetMatchedOnCurrentPageViewFlag = (
+    audience: MatchedAudience
+  ): MatchedAudience => ({
+    ...audience,
+    matchedOnCurrentPageView: false,
+  });
+
+  const matchedAudienceId = 'testId';
+  const fixedAudienceId = 'fixedAudienceId';
+
+  const [
+    matchedAudience,
+    matchedAudienceDefinition,
+  ] = makeMatchedAudienceAndDefinition(matchedAudienceId, 1);
+  const [
+    fixedMatchedAudience,
+    fixedAudienceDefinition,
+  ] = makeMatchedAudienceAndDefinition(fixedAudienceId, 1);
+
+  const [
+    _rematchedAudience,
+    rematchedAudienceDefinition,
+  ] = makeMatchedAudienceAndDefinition(matchedAudienceId, 2);
+  const rematchedAudience = unsetMatchedOnCurrentPageViewFlag(
+    _rematchedAudience
+  );
+
+  const [
+    newlyMatchedAudience,
+    newlyMatchedAudienceDefinition,
+  ] = makeMatchedAudienceAndDefinition('totallyNewAudience', 1);
+
+  const oldMatchedAudience = unsetMatchedOnCurrentPageViewFlag(matchedAudience);
+  const oldFixedMatchedAudience = unsetMatchedOnCurrentPageViewFlag(
+    fixedMatchedAudience
+  );
+
+  beforeAll(clearStore);
+
+  // triggers load as in a new edkt run
+  beforeEach(() => matchedAudienceStore._load());
+
+  it('should set `matchedOnCurrentPageView` flag for newly matched audiences', () => {
+    const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(matchedAudiences).toHaveLength(0);
+
+    matchedAudienceStore.updateMatchedAudiences(
+      [
+        matchedAudience,
+        fixedMatchedAudience, // add this so we know we don't mess with the other audiences
+      ],
+      [matchedAudienceDefinition, fixedAudienceDefinition]
+    );
+
+    const storedMatchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(storedMatchedAudiences).toHaveLength(2);
+    expect(storedMatchedAudiences).toContainEqual(matchedAudience);
+    expect(storedMatchedAudiences).toContainEqual(fixedMatchedAudience);
+  });
+
+  it('should unset `matchedOnCurrentPageView` flag on load', () => {
+    const oldMatchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(oldMatchedAudiences).toHaveLength(2);
+    expect(oldMatchedAudiences).toContainEqual(oldMatchedAudience);
+    expect(oldMatchedAudiences).toContainEqual(oldFixedMatchedAudience);
+  });
+
+  it('should preserve `matchedOnCurrentPageView` flag and timestamps on rematched audiences', () => {
+    matchedAudienceStore.updateMatchedAudiences(
+      [rematchedAudience],
+      [rematchedAudienceDefinition, fixedAudienceDefinition]
+    );
+
+    const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(matchedAudiences).toHaveLength(2);
+    expect(matchedAudiences).toContainEqual(rematchedAudience);
+    expect(matchedAudiences).toContainEqual(oldFixedMatchedAudience);
+  });
+
+  it('should not mess with old audiences on new additions', () => {
+    matchedAudienceStore.updateMatchedAudiences(
+      [newlyMatchedAudience],
+      [
+        newlyMatchedAudienceDefinition,
+        rematchedAudienceDefinition,
+        fixedAudienceDefinition,
+      ]
+    );
+
+    const oldRematchedAudience = unsetMatchedOnCurrentPageViewFlag(
+      rematchedAudience
+    );
+
+    const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(matchedAudiences).toHaveLength(3);
+    expect(matchedAudiences).toContainEqual(newlyMatchedAudience);
+    expect(matchedAudiences).toContainEqual(oldRematchedAudience);
+    expect(matchedAudiences).toContainEqual(oldFixedMatchedAudience);
+  });
+});

--- a/test/unit/store/matchedAudiences.test.ts
+++ b/test/unit/store/matchedAudiences.test.ts
@@ -31,9 +31,9 @@ describe('matchedAudienceStore set and load behaviour', () => {
     matchedOnCurrentPageView: false,
   });
 
-  const matchedAudienceId = 'testId';
+  const matchedAudienceId = 'matchedAudienceId';
   const fixedAudienceId = 'fixedAudienceId';
-  const newlyMatchedAudienceId = 'totallyNewAudience';
+  const newlyMatchedAudienceId = 'newlyMatchedAudienceId';
 
   // matchedAudiences and definitions
   const [
@@ -106,7 +106,7 @@ describe('matchedAudienceStore set and load behaviour', () => {
 
   it('should preserve `matchedOnCurrentPageView` flag and timestamps on rematched audiences', () => {
     matchedAudienceStore.updateMatchedAudiences(
-      [rematchedAudience],
+      [rematchedAudience, oldFixedMatchedAudience],
       [rematchedAudienceDefinition, fixedAudienceDefinition]
     );
 

--- a/test/unit/store/matchedAudiences.test.ts
+++ b/test/unit/store/matchedAudiences.test.ts
@@ -70,6 +70,9 @@ describe('matchedAudienceStore set and load behaviour', () => {
   const oldRematchedAudience = unsetMatchedOnCurrentPageViewFlag(
     rematchedAudience
   );
+  const oldNewlyMatchedAudience = unsetMatchedOnCurrentPageViewFlag(
+    newlyMatchedAudience
+  );
 
   beforeAll(clearStore);
 
@@ -126,6 +129,35 @@ describe('matchedAudienceStore set and load behaviour', () => {
     const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
     expect(matchedAudiences).toHaveLength(3);
     expect(matchedAudiences).toContainEqual(newlyMatchedAudience);
+    expect(matchedAudiences).toContainEqual(oldRematchedAudience);
+    expect(matchedAudiences).toContainEqual(oldFixedMatchedAudience);
+  });
+
+  it('should not mess with old audiences on no new additions', () => {
+    matchedAudienceStore.updateMatchedAudiences(
+      [],
+      [
+        newlyMatchedAudienceDefinition,
+        rematchedAudienceDefinition,
+        fixedAudienceDefinition,
+      ]
+    );
+
+    const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(matchedAudiences).toHaveLength(3);
+    expect(matchedAudiences).toContainEqual(oldNewlyMatchedAudience);
+    expect(matchedAudiences).toContainEqual(oldRematchedAudience);
+    expect(matchedAudiences).toContainEqual(oldFixedMatchedAudience);
+  });
+
+  it('should remove matchedAudiences on audienceDefinition removal', () => {
+    matchedAudienceStore.updateMatchedAudiences(
+      [],
+      [rematchedAudienceDefinition, fixedAudienceDefinition]
+    );
+
+    const matchedAudiences = matchedAudienceStore.getMatchedAudiences();
+    expect(matchedAudiences).toHaveLength(2);
     expect(matchedAudiences).toContainEqual(oldRematchedAudience);
     expect(matchedAudiences).toContainEqual(oldFixedMatchedAudience);
   });


### PR DESCRIPTION
I've added a MatchedAudienceStore test case, just to make its behaviour clear in a more direct way (without running through all the edkt run code).

Also, I've changed the `matchedAudienceStore.setMatchedAudiences` to `updateMatchedAudiences`, which takes both the newly matched audiences and the audience definitions used for matching. It is needed so the store can drop the version bumped audiences that are not matched anymore.
Take a look and please let me know of any changes needed. =)

Closes https://github.com/AirGrid/edgekit/issues/147
Closes https://github.com/AirGrid/edgekit/issues/133