### PR TITLE
Remove unnecessary test helpers

### DIFF
--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -24,6 +24,8 @@ describe('edgekit basic run behaviour', () => {
   // look at jest-playwright.config.js
   const testUrl = 'http://localhost:9000';
 
+  const matchingVector = [1, 1, 1];
+
   const topicModelAudience = makeAudienceDefinition({
     id: 'topic_dist_model_id',
     occurrences: 1,
@@ -31,7 +33,7 @@ describe('edgekit basic run behaviour', () => {
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: [0.2, 0.5, 0.1],
+          vector: matchingVector,
         },
       }),
     ],
@@ -40,7 +42,7 @@ describe('edgekit basic run behaviour', () => {
   const pageFeatures = {
     docVector: {
       version: 1,
-      value: [0.2, 0.5, 0.1],
+      value: matchingVector,
     },
   };
 

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -2,16 +2,17 @@ import {
   makeAudienceDefinition,
   makeCosineSimilarityQuery,
 } from '../helpers/audienceDefinitions';
+import { StorageKeys } from '../../types';
 
 type Store = { edkt_matched_audiences: string; edkt_page_views: string };
 
 const getPageViewsFromStore = (store: Store) =>
-  JSON.parse(store['edkt_page_views']);
+  JSON.parse(store[StorageKeys.PAGE_VIEWS]);
 
 const getMatchedAudiencesFromStore = (store: Store) => {
   // TODO: this is added for backward compat.
   // https://github.com/AirGrid/edgekit/issues/152
-  const matchedAudiences = JSON.parse(store['edkt_matched_audiences']);
+  const matchedAudiences = JSON.parse(store[StorageKeys.MATCHED_AUDIENCES]);
   return Object.entries(matchedAudiences).map(([_, audience]) => audience);
 };
 

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -22,9 +22,9 @@ const getLocalStorageFromPage = (): Promise<Store> =>
 describe('edgekit basic run behaviour', () => {
   // We are serving a mock page with the edgekit transpiled code.
   // look at jest-playwright.config.js
-  const testUrl = 'http://localhost:9000';
+  const TEST_URL = 'http://localhost:9000';
 
-  const matchingVector = [1, 1, 1];
+  const MATCHING_VECTOR = [1, 1, 1];
 
   const topicModelAudience = makeAudienceDefinition({
     id: 'topic_dist_model_id',
@@ -33,7 +33,7 @@ describe('edgekit basic run behaviour', () => {
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: matchingVector,
+          vector: MATCHING_VECTOR,
         },
       }),
     ],
@@ -42,7 +42,7 @@ describe('edgekit basic run behaviour', () => {
   const pageFeatures = {
     docVector: {
       version: 1,
-      value: matchingVector,
+      value: MATCHING_VECTOR,
     },
   };
 
@@ -58,7 +58,7 @@ describe('edgekit basic run behaviour', () => {
     });
 
   beforeAll(async () => {
-    await page.goto(`${testUrl}?edktDebug=true`, { waitUntil: 'networkidle' });
+    await page.goto(`${TEST_URL}?edktDebug=true`, { waitUntil: 'networkidle' });
   });
 
   it('runs and adds pageView to store', async () => {

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -7,6 +7,7 @@ type Store = { edkt_matched_audiences: string; edkt_page_views: string };
 
 const getPageViewsFromStore = (store: Store) =>
   JSON.parse(store['edkt_page_views']);
+
 const getMatchedAudiencesFromStore = (store: Store) => {
   // TODO: this is added for backward compat.
   // https://github.com/AirGrid/edgekit/issues/152

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -57,36 +57,3 @@ export const makeLogisticRegressionQuery = ({
   ...partialAudienceQueryDefinition,
   queryValue,
 });
-
-export const logRegAudience = makeAudienceDefinition({
-  occurrences: 1,
-  definition: [
-    makeLogisticRegressionQuery({
-      queryValue: {
-        threshold: 0.9,
-        vector: [1, 1, 1],
-        bias: 0,
-      },
-    }),
-  ],
-});
-
-export const multiLogRegAudience = makeAudienceDefinition({
-  occurrences: 1,
-  definition: [
-    makeLogisticRegressionQuery({
-      queryValue: {
-        threshold: 0.9,
-        vector: [1, 1, 1],
-        bias: 0,
-      },
-    }),
-    makeLogisticRegressionQuery({
-      queryValue: {
-        threshold: 0.9,
-        vector: [1, 0, 1],
-        bias: 1,
-      },
-    }),
-  ],
-});

--- a/test/helpers/audienceDefinitions.ts
+++ b/test/helpers/audienceDefinitions.ts
@@ -43,36 +43,6 @@ export const makeCosineSimilarityQuery = ({
   queryValue,
 });
 
-export const cosineSimAudience = makeAudienceDefinition({
-  occurrences: 1,
-  definition: [
-    makeCosineSimilarityQuery({
-      queryValue: {
-        threshold: 0.99,
-        vector: [1, 1, 1],
-      },
-    }),
-  ],
-});
-
-export const multiCosineSimAudience = makeAudienceDefinition({
-  occurrences: 1,
-  definition: [
-    makeCosineSimilarityQuery({
-      queryValue: {
-        threshold: 0.99,
-        vector: [1, 1, 1],
-      },
-    }),
-    makeCosineSimilarityQuery({
-      queryValue: {
-        threshold: 0.99,
-        vector: [1, 0, 1],
-      },
-    }),
-  ],
-});
-
 // logistic regression audiences
 
 export const makeLogisticRegressionQuery = ({

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -27,8 +27,8 @@ export const makeEngineCondition = <T extends AudienceQueryDefinition>({
         name: 'count',
       },
       matcher: {
-        name: condition || 'ge',
-        args: occurences || 1,
+        name: condition !== undefined ? condition : 'gt',
+        args: occurences !== undefined ? occurences : 0,
       },
     },
   ],
@@ -38,7 +38,7 @@ type MakePageViewInput = {
   value: number[];
   version: number;
   ts?: number;
-  queryProperty?: string;
+  queryProperty: string;
 };
 
 export const makePageView = ({
@@ -49,7 +49,7 @@ export const makePageView = ({
 }: MakePageViewInput): PageView => ({
   ts: ts || 100,
   features: {
-    [queryProperty || 'docVector']: {
+    [queryProperty]: {
       version,
       value,
     },

--- a/test/helpers/engineConditions.ts
+++ b/test/helpers/engineConditions.ts
@@ -6,11 +6,17 @@ import {
   EngineConditionRule,
 } from '../../types';
 
-export const makeEngineCondition = <T extends AudienceQueryDefinition>(
-  queries: EngineConditionQuery<T>[],
-  occurences: EngineConditionRule['matcher']['args'] = 1,
-  condition: EngineConditionRule['matcher']['name'] = 'ge'
-): EngineCondition<T> => ({
+type MakeEngineConditionInput<T extends AudienceQueryDefinition> = {
+  queries: EngineConditionQuery<T>[];
+  occurences?: EngineConditionRule['matcher']['args'];
+  condition?: EngineConditionRule['matcher']['name'];
+};
+
+export const makeEngineCondition = <T extends AudienceQueryDefinition>({
+  queries,
+  occurences,
+  condition,
+}: MakeEngineConditionInput<T>): EngineCondition<T> => ({
   filter: {
     any: false,
     queries,
@@ -21,22 +27,29 @@ export const makeEngineCondition = <T extends AudienceQueryDefinition>(
         name: 'count',
       },
       matcher: {
-        name: condition,
-        args: occurences,
+        name: condition || 'ge',
+        args: occurences || 1,
       },
     },
   ],
 });
 
-export const makePageView = (
-  value: number[],
-  version: number,
-  ts = 100,
-  queryProperty = 'docVector'
-): PageView => ({
+type MakePageViewInput = {
+  value: number[];
+  version: number;
+  ts?: number;
+  queryProperty?: string;
+};
+
+export const makePageView = ({
+  value,
+  version,
   ts,
+  queryProperty,
+}: MakePageViewInput): PageView => ({
+  ts: ts || 100,
   features: {
-    [queryProperty]: {
+    [queryProperty || 'docVector']: {
       version,
       value,
     },

--- a/test/helpers/localStorage.ts
+++ b/test/helpers/localStorage.ts
@@ -1,5 +1,7 @@
-import { PageView, MatchedAudience, MatchedAudiences } from '../../types';
+import { PageView, MatchedAudience } from '../../types';
 import { viewStore, matchedAudienceStore } from '../../src/store';
+import { StorageKeys } from '../../types';
+import { storage } from '../../src/utils';
 
 export const clearStore = (): void => {
   localStorage.clear();
@@ -10,24 +12,23 @@ export const clearStore = (): void => {
 
 export const setUpLocalStorage = (pageViews: PageView[]): void => {
   localStorage.clear();
-  localStorage.setItem('edkt_page_views', JSON.stringify(pageViews));
+  storage.set(StorageKeys.PAGE_VIEWS, pageViews);
   // We need to reload from local storage because its only done on construction
   viewStore._load();
   matchedAudienceStore._load();
 };
 
 export const getPageViews = (): PageView[] =>
-  JSON.parse(localStorage.getItem('edkt_page_views') || '[]');
+  storage.get(StorageKeys.PAGE_VIEWS);
 
 export const getMatchedAudiences = (): MatchedAudience[] => {
-  const matchedAudiences: MatchedAudiences = JSON.parse(
-    localStorage.getItem('edkt_matched_audiences') || '{}'
+  const matchedAudiences: MatchedAudience = storage.get(
+    StorageKeys.MATCHED_AUDIENCES
   );
   // TODO: this code has been added for backward compat
   // https://github.com/AirGrid/edgekit/issues/152
   return Object.entries(matchedAudiences).map(([_, audience]) => audience);
 };
 
-export const getMatchedAudienceIds = (): MatchedAudience[] => {
-  return JSON.parse(localStorage.getItem('edkt_matched_audience_ids') || '[]');
-};
+export const getMatchedAudienceIds = (): string[] =>
+  storage.get(StorageKeys.MATCHED_AUDIENCE_IDS);

--- a/test/unit/audience/cosineSimilarityQueryAudience.test.ts
+++ b/test/unit/audience/cosineSimilarityQueryAudience.test.ts
@@ -5,11 +5,41 @@ import {
   getPageViews,
 } from '../../helpers/localStorage';
 import {
-  cosineSimAudience,
-  multiCosineSimAudience,
+  makeAudienceDefinition,
+  makeCosineSimilarityQuery,
 } from '../../helpers/audienceDefinitions';
 
 describe('cosine similarity audiences matching behaviour', () => {
+  const cosineSimAudience = makeAudienceDefinition({
+    occurrences: 1,
+    definition: [
+      makeCosineSimilarityQuery({
+        queryValue: {
+          threshold: 0.99,
+          vector: [1, 1, 1],
+        },
+      }),
+    ],
+  });
+
+  const multiCosineSimAudience = makeAudienceDefinition({
+    occurrences: 1,
+    definition: [
+      makeCosineSimilarityQuery({
+        queryValue: {
+          threshold: 0.99,
+          vector: [1, 1, 1],
+        },
+      }),
+      makeCosineSimilarityQuery({
+        queryValue: {
+          threshold: 0.99,
+          vector: [1, 0, 1],
+        },
+      }),
+    ],
+  });
+
   describe('cosine similarity with single query audiences', () => {
     const pageFeatures = {
       docVector: {

--- a/test/unit/audience/cosineSimilarityQueryAudience.test.ts
+++ b/test/unit/audience/cosineSimilarityQueryAudience.test.ts
@@ -10,13 +10,17 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('cosine similarity audiences matching behaviour', () => {
+  const vectorOne = [1, 1, 1];
+  const vectorTwo = [1, 0, 1];
+  const notMatchingVector = [0, 1, 0];
+
   const cosineSimAudience = makeAudienceDefinition({
     occurrences: 1,
     definition: [
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: [1, 1, 1],
+          vector: vectorOne,
         },
       }),
     ],
@@ -28,13 +32,13 @@ describe('cosine similarity audiences matching behaviour', () => {
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: [1, 1, 1],
+          vector: vectorOne,
         },
       }),
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: [1, 0, 1],
+          vector: vectorTwo,
         },
       }),
     ],
@@ -43,7 +47,7 @@ describe('cosine similarity audiences matching behaviour', () => {
   describe('cosine similarity with single query audiences', () => {
     const pageFeatures = {
       docVector: {
-        value: [1, 1, 1],
+        value: vectorOne,
         version: 1,
       },
     };
@@ -83,16 +87,16 @@ describe('cosine similarity audiences matching behaviour', () => {
   });
 
   describe('cosine similarity multi query audiences matching above threshold', () => {
-    const pageFeaturesMatch0 = {
+    const pageFeaturesMatchOne = {
       docVector: {
-        value: [1, 1, 1],
+        value: vectorOne,
         version: 1,
       },
     };
 
-    const pageFeaturesMatch1 = {
+    const pageFeaturesMatchTwo = {
       docVector: {
-        value: [1, 0, 1],
+        value: vectorTwo,
         version: 1,
       },
     };
@@ -101,7 +105,7 @@ describe('cosine similarity audiences matching behaviour', () => {
 
     it('adds 1st page view and does not match on first run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch0,
+        pageFeatures: pageFeaturesMatchOne,
         audienceDefinitions: [multiCosineSimAudience],
         omitGdprConsent: true,
       });
@@ -112,7 +116,7 @@ describe('cosine similarity audiences matching behaviour', () => {
 
     it('adds 2nd page view and match second run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch1,
+        pageFeatures: pageFeaturesMatchTwo,
         audienceDefinitions: [multiCosineSimAudience],
         omitGdprConsent: true,
       });
@@ -123,7 +127,7 @@ describe('cosine similarity audiences matching behaviour', () => {
 
     it('adds 3rd page view third run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch0,
+        pageFeatures: pageFeaturesMatchOne,
         audienceDefinitions: [cosineSimAudience],
         omitGdprConsent: true,
       });
@@ -136,7 +140,7 @@ describe('cosine similarity audiences matching behaviour', () => {
   describe('cosine similarity multi query audiences not matching below threshold', () => {
     const pageFeaturesNotMatch = {
       docVector: {
-        value: [0, 1, 0],
+        value: notMatchingVector,
         version: 1,
       },
     };

--- a/test/unit/audience/cosineSimilarityQueryAudience.test.ts
+++ b/test/unit/audience/cosineSimilarityQueryAudience.test.ts
@@ -10,9 +10,9 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('cosine similarity audiences matching behaviour', () => {
-  const vectorOne = [1, 1, 1];
-  const vectorTwo = [1, 0, 1];
-  const notMatchingVector = [0, 1, 0];
+  const VECTOR_ONE = [1, 1, 1];
+  const VECTOR_TWO = [1, 0, 1];
+  const NOT_MATCHING_VECTOR = [0, 1, 0];
 
   const cosineSimAudience = makeAudienceDefinition({
     occurrences: 1,
@@ -20,7 +20,7 @@ describe('cosine similarity audiences matching behaviour', () => {
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: vectorOne,
+          vector: VECTOR_ONE,
         },
       }),
     ],
@@ -32,13 +32,13 @@ describe('cosine similarity audiences matching behaviour', () => {
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: vectorOne,
+          vector: VECTOR_ONE,
         },
       }),
       makeCosineSimilarityQuery({
         queryValue: {
           threshold: 0.99,
-          vector: vectorTwo,
+          vector: VECTOR_TWO,
         },
       }),
     ],
@@ -47,7 +47,7 @@ describe('cosine similarity audiences matching behaviour', () => {
   describe('cosine similarity with single query audiences', () => {
     const pageFeatures = {
       docVector: {
-        value: vectorOne,
+        value: VECTOR_ONE,
         version: 1,
       },
     };
@@ -89,14 +89,14 @@ describe('cosine similarity audiences matching behaviour', () => {
   describe('cosine similarity multi query audiences matching above threshold', () => {
     const pageFeaturesMatchOne = {
       docVector: {
-        value: vectorOne,
+        value: VECTOR_ONE,
         version: 1,
       },
     };
 
     const pageFeaturesMatchTwo = {
       docVector: {
-        value: vectorTwo,
+        value: VECTOR_TWO,
         version: 1,
       },
     };
@@ -140,7 +140,7 @@ describe('cosine similarity audiences matching behaviour', () => {
   describe('cosine similarity multi query audiences not matching below threshold', () => {
     const pageFeaturesNotMatch = {
       docVector: {
-        value: notMatchingVector,
+        value: NOT_MATCHING_VECTOR,
         version: 1,
       },
     };

--- a/test/unit/audience/logisticRegressionQueryAudience.test.ts
+++ b/test/unit/audience/logisticRegressionQueryAudience.test.ts
@@ -10,9 +10,9 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('logistic regression audiences matching behaviour', () => {
-  const vectorOne = [1, 1, 1];
-  const vectorTwo = [1, 0, 1];
-  const notMatchingVector = [0, 1, 0];
+  const VECTOR_ONE = [1, 1, 1];
+  const VECTOR_TWO = [1, 0, 1];
+  const NOT_MATCHING_VECTOR = [0, 1, 0];
 
   const logRegAudience = makeAudienceDefinition({
     occurrences: 1,
@@ -20,7 +20,7 @@ describe('logistic regression audiences matching behaviour', () => {
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: vectorOne,
+          vector: VECTOR_ONE,
           bias: 0,
         },
       }),
@@ -33,14 +33,14 @@ describe('logistic regression audiences matching behaviour', () => {
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: vectorOne,
+          vector: VECTOR_ONE,
           bias: 0,
         },
       }),
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: vectorTwo,
+          vector: VECTOR_TWO,
           bias: 1,
         },
       }),
@@ -50,7 +50,7 @@ describe('logistic regression audiences matching behaviour', () => {
   describe('logistic regression with single query audiences', () => {
     const pageFeatures = {
       docVector: {
-        value: vectorOne,
+        value: VECTOR_ONE,
         version: 1,
       },
     };
@@ -92,14 +92,14 @@ describe('logistic regression audiences matching behaviour', () => {
   describe('logistic regression multi query audiences matching above threshold', () => {
     const pageFeaturesMatchOne = {
       docVector: {
-        value: vectorOne,
+        value: VECTOR_ONE,
         version: 1,
       },
     };
 
     const pageFeaturesMatchTwo = {
       docVector: {
-        value: vectorTwo,
+        value: VECTOR_TWO,
         version: 1,
       },
     };
@@ -143,7 +143,7 @@ describe('logistic regression audiences matching behaviour', () => {
   describe('logistic regression multi query audiences not matching below threshold', () => {
     const pageFeaturesNotMatch = {
       docVector: {
-        value: notMatchingVector,
+        value: NOT_MATCHING_VECTOR,
         version: 1,
       },
     };

--- a/test/unit/audience/logisticRegressionQueryAudience.test.ts
+++ b/test/unit/audience/logisticRegressionQueryAudience.test.ts
@@ -5,11 +5,44 @@ import {
   getPageViews,
 } from '../../helpers/localStorage';
 import {
-  logRegAudience,
-  multiLogRegAudience,
+  makeAudienceDefinition,
+  makeLogisticRegressionQuery,
 } from '../../helpers/audienceDefinitions';
 
 describe('logistic regression audiences matching behaviour', () => {
+  const logRegAudience = makeAudienceDefinition({
+    occurrences: 1,
+    definition: [
+      makeLogisticRegressionQuery({
+        queryValue: {
+          threshold: 0.9,
+          vector: [1, 1, 1],
+          bias: 0,
+        },
+      }),
+    ],
+  });
+
+  const multiLogRegAudience = makeAudienceDefinition({
+    occurrences: 1,
+    definition: [
+      makeLogisticRegressionQuery({
+        queryValue: {
+          threshold: 0.9,
+          vector: [1, 1, 1],
+          bias: 0,
+        },
+      }),
+      makeLogisticRegressionQuery({
+        queryValue: {
+          threshold: 0.9,
+          vector: [1, 0, 1],
+          bias: 1,
+        },
+      }),
+    ],
+  });
+
   describe('logistic regression with single query audiences', () => {
     const pageFeatures = {
       docVector: {

--- a/test/unit/audience/logisticRegressionQueryAudience.test.ts
+++ b/test/unit/audience/logisticRegressionQueryAudience.test.ts
@@ -10,13 +10,17 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('logistic regression audiences matching behaviour', () => {
+  const vectorOne = [1, 1, 1];
+  const vectorTwo = [1, 0, 1];
+  const notMatchingVector = [0, 1, 0];
+
   const logRegAudience = makeAudienceDefinition({
     occurrences: 1,
     definition: [
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: [1, 1, 1],
+          vector: vectorOne,
           bias: 0,
         },
       }),
@@ -29,14 +33,14 @@ describe('logistic regression audiences matching behaviour', () => {
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: [1, 1, 1],
+          vector: vectorOne,
           bias: 0,
         },
       }),
       makeLogisticRegressionQuery({
         queryValue: {
           threshold: 0.9,
-          vector: [1, 0, 1],
+          vector: vectorTwo,
           bias: 1,
         },
       }),
@@ -46,7 +50,7 @@ describe('logistic regression audiences matching behaviour', () => {
   describe('logistic regression with single query audiences', () => {
     const pageFeatures = {
       docVector: {
-        value: [1, 1, 1],
+        value: vectorOne,
         version: 1,
       },
     };
@@ -86,16 +90,16 @@ describe('logistic regression audiences matching behaviour', () => {
   });
 
   describe('logistic regression multi query audiences matching above threshold', () => {
-    const pageFeaturesMatch0 = {
+    const pageFeaturesMatchOne = {
       docVector: {
-        value: [1, 1, 1],
+        value: vectorOne,
         version: 1,
       },
     };
 
-    const pageFeaturesMatch1 = {
+    const pageFeaturesMatchTwo = {
       docVector: {
-        value: [1, 0, 1],
+        value: vectorTwo,
         version: 1,
       },
     };
@@ -104,7 +108,7 @@ describe('logistic regression audiences matching behaviour', () => {
 
     it('adds 1st page view and does not match on first run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch0,
+        pageFeatures: pageFeaturesMatchOne,
         audienceDefinitions: [multiLogRegAudience],
         omitGdprConsent: true,
       });
@@ -115,7 +119,7 @@ describe('logistic regression audiences matching behaviour', () => {
 
     it('adds 2nd page view and match second run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch1,
+        pageFeatures: pageFeaturesMatchTwo,
         audienceDefinitions: [multiLogRegAudience],
         omitGdprConsent: true,
       });
@@ -126,7 +130,7 @@ describe('logistic regression audiences matching behaviour', () => {
 
     it('adds 3rd page view third run', async () => {
       await edkt.run({
-        pageFeatures: pageFeaturesMatch0,
+        pageFeatures: pageFeaturesMatchOne,
         audienceDefinitions: [logRegAudience],
         omitGdprConsent: true,
       });
@@ -139,7 +143,7 @@ describe('logistic regression audiences matching behaviour', () => {
   describe('logistic regression multi query audiences not matching below threshold', () => {
     const pageFeaturesNotMatch = {
       docVector: {
-        value: [0, 1, 0],
+        value: notMatchingVector,
         version: 1,
       },
     };

--- a/test/unit/audience/multipleAudienceTypes.test.ts
+++ b/test/unit/audience/multipleAudienceTypes.test.ts
@@ -11,11 +11,11 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('multiple audiences types matching behaviour', () => {
-  const cosSimId = 'cosSimAudience';
-  const logRegId = 'logRegAudience';
+  const COS_SIM_ID = 'cosSimAudience';
+  const LOG_REG_ID = 'logRegAudience';
 
-  const matchingVector = [1, 1, 1];
-  const notMatchingVector = [0, 0, 0];
+  const MATCHING_VECTOR = [1, 1, 1];
+  const NOT_MATCHING_VECTOR = [0, 0, 0];
 
   type AudienceFactoryInput = {
     vector: number[];
@@ -27,7 +27,7 @@ describe('multiple audiences types matching behaviour', () => {
     queryProperty,
   }: AudienceFactoryInput) =>
     makeAudienceDefinition({
-      id: logRegId,
+      id: LOG_REG_ID,
       occurrences: 0,
       definition: [
         makeLogisticRegressionQuery({
@@ -46,7 +46,7 @@ describe('multiple audiences types matching behaviour', () => {
     queryProperty,
   }: AudienceFactoryInput) =>
     makeAudienceDefinition({
-      id: cosSimId,
+      id: COS_SIM_ID,
       occurrences: 0,
       definition: [
         makeCosineSimilarityQuery({
@@ -63,11 +63,11 @@ describe('multiple audiences types matching behaviour', () => {
 
   describe('multiple audiences with different features', () => {
     const logRegAudience = makeLogRegAudience({
-      vector: matchingVector,
+      vector: MATCHING_VECTOR,
       queryProperty: 'logRegVector',
     });
     const cosSimAudience = makeCosSimAudience({
-      vector: matchingVector,
+      vector: MATCHING_VECTOR,
       queryProperty: 'cosSimVector',
     });
 
@@ -76,11 +76,11 @@ describe('multiple audiences types matching behaviour', () => {
     describe('logistic regression plus cosine similarity audiences, query matching both', () => {
       const pageFeatures = {
         cosSimVector: {
-          value: matchingVector,
+          value: MATCHING_VECTOR,
           version: 1,
         },
         logRegVector: {
-          value: matchingVector,
+          value: MATCHING_VECTOR,
           version: 1,
         },
       };
@@ -98,12 +98,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(2);
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });
@@ -112,11 +112,11 @@ describe('multiple audiences types matching behaviour', () => {
     describe('logistic regression plus cosine similarity audiences, query matching cosSim only', () => {
       const pageFeatures = {
         cosSimVector: {
-          value: matchingVector,
+          value: MATCHING_VECTOR,
           version: 1,
         },
         logRegVector: {
-          value: notMatchingVector,
+          value: NOT_MATCHING_VECTOR,
           version: 1,
         },
       };
@@ -134,12 +134,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(1);
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).not.toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });
@@ -148,11 +148,11 @@ describe('multiple audiences types matching behaviour', () => {
     describe('logistic regression plus cosine similarity audiences, query matching logReg only', () => {
       const pageFeatures = {
         cosSimVector: {
-          value: notMatchingVector,
+          value: NOT_MATCHING_VECTOR,
           version: 1,
         },
         logRegVector: {
-          value: matchingVector,
+          value: MATCHING_VECTOR,
           version: 1,
         },
       };
@@ -170,12 +170,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(1);
         expect(matchedAudiences).not.toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });
@@ -185,18 +185,18 @@ describe('multiple audiences types matching behaviour', () => {
   describe('multiple audiences with same features', () => {
     const pageFeatures = {
       logRegVector: {
-        value: matchingVector,
+        value: MATCHING_VECTOR,
         version: 1,
       },
     };
 
     describe('logistic regression plus cosine similarity audiences, query matching both', () => {
       const cosSimAudience = makeCosSimAudience({
-        vector: matchingVector,
+        vector: MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       });
       const logRegAudience = makeLogRegAudience({
-        vector: matchingVector,
+        vector: MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
@@ -214,12 +214,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(2);
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });
@@ -227,11 +227,11 @@ describe('multiple audiences types matching behaviour', () => {
 
     describe('logistic regression plus cosine similarity audiences, query matching cosSim only', () => {
       const cosSimAudience = makeCosSimAudience({
-        vector: matchingVector,
+        vector: MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       });
       const logRegAudience = makeLogRegAudience({
-        vector: notMatchingVector,
+        vector: NOT_MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
@@ -249,12 +249,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(1);
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).not.toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });
@@ -262,11 +262,11 @@ describe('multiple audiences types matching behaviour', () => {
 
     describe('logistic regression plus cosine similarity audiences, query matching logReg only', () => {
       const cosSimAudience = makeCosSimAudience({
-        vector: notMatchingVector,
+        vector: NOT_MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       }); // doesn't match
       const logRegAudience = makeLogRegAudience({
-        vector: matchingVector,
+        vector: MATCHING_VECTOR,
         queryProperty: 'logRegVector',
       });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
@@ -284,12 +284,12 @@ describe('multiple audiences types matching behaviour', () => {
         expect(matchedAudiences).toHaveLength(1);
         expect(matchedAudiences).not.toContainEqual(
           expect.objectContaining({
-            id: cosSimId,
+            id: COS_SIM_ID,
           })
         );
         expect(matchedAudiences).toContainEqual(
           expect.objectContaining({
-            id: logRegId,
+            id: LOG_REG_ID,
           })
         );
       });

--- a/test/unit/audience/multipleAudienceTypes.test.ts
+++ b/test/unit/audience/multipleAudienceTypes.test.ts
@@ -14,7 +14,18 @@ describe('multiple audiences types matching behaviour', () => {
   const cosSimId = 'cosSimAudience';
   const logRegId = 'logRegAudience';
 
-  const makeLogRegAudience = (vector: number[], queryProperty = 'docVector') =>
+  const matchingVector = [1, 1, 1];
+  const notMatchingVector = [0, 0, 0];
+
+  type AudienceFactoryInput = {
+    vector: number[];
+    queryProperty: string;
+  };
+
+  const makeLogRegAudience = ({
+    vector,
+    queryProperty,
+  }: AudienceFactoryInput) =>
     makeAudienceDefinition({
       id: logRegId,
       occurrences: 0,
@@ -30,10 +41,10 @@ describe('multiple audiences types matching behaviour', () => {
       ],
     });
 
-  const makeCosSimAudience = (
-    vector: number[],
-    queryProperty = 'featureVector'
-  ) =>
+  const makeCosSimAudience = ({
+    vector,
+    queryProperty,
+  }: AudienceFactoryInput) =>
     makeAudienceDefinition({
       id: cosSimId,
       occurrences: 0,
@@ -51,19 +62,25 @@ describe('multiple audiences types matching behaviour', () => {
   beforeEach(clearStore);
 
   describe('multiple audiences with different features', () => {
-    const logRegAudience = makeLogRegAudience([1, 1, 1]);
-    const cosSimAudience = makeCosSimAudience([1, 1, 1]);
+    const logRegAudience = makeLogRegAudience({
+      vector: matchingVector,
+      queryProperty: 'logRegVector',
+    });
+    const cosSimAudience = makeCosSimAudience({
+      vector: matchingVector,
+      queryProperty: 'cosSimVector',
+    });
 
     const audienceDefinitions = [cosSimAudience, logRegAudience];
 
     describe('logistic regression plus cosine similarity audiences, query matching both', () => {
       const pageFeatures = {
-        featureVector: {
-          value: [1, 1, 1],
+        cosSimVector: {
+          value: matchingVector,
           version: 1,
         },
-        docVector: {
-          value: [1, 1, 1],
+        logRegVector: {
+          value: matchingVector,
           version: 1,
         },
       };
@@ -94,12 +111,12 @@ describe('multiple audiences types matching behaviour', () => {
 
     describe('logistic regression plus cosine similarity audiences, query matching cosSim only', () => {
       const pageFeatures = {
-        featureVector: {
-          value: [1, 1, 1],
+        cosSimVector: {
+          value: matchingVector,
           version: 1,
         },
-        docVector: {
-          value: [0, 0, 0], //doesn't match
+        logRegVector: {
+          value: notMatchingVector,
           version: 1,
         },
       };
@@ -130,12 +147,12 @@ describe('multiple audiences types matching behaviour', () => {
 
     describe('logistic regression plus cosine similarity audiences, query matching logReg only', () => {
       const pageFeatures = {
-        featureVector: {
-          value: [0, 0, 0], //doesn't match
+        cosSimVector: {
+          value: notMatchingVector,
           version: 1,
         },
-        docVector: {
-          value: [1, 1, 1],
+        logRegVector: {
+          value: matchingVector,
           version: 1,
         },
       };
@@ -167,15 +184,21 @@ describe('multiple audiences types matching behaviour', () => {
 
   describe('multiple audiences with same features', () => {
     const pageFeatures = {
-      docVector: {
-        value: [1, 1, 1],
+      logRegVector: {
+        value: matchingVector,
         version: 1,
       },
     };
 
     describe('logistic regression plus cosine similarity audiences, query matching both', () => {
-      const cosSimAudience = makeCosSimAudience([1, 1, 1], 'docVector');
-      const logRegAudience = makeLogRegAudience([1, 1, 1], 'docVector');
+      const cosSimAudience = makeCosSimAudience({
+        vector: matchingVector,
+        queryProperty: 'logRegVector',
+      });
+      const logRegAudience = makeLogRegAudience({
+        vector: matchingVector,
+        queryProperty: 'logRegVector',
+      });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
 
       it('adds page view and does match both audiences', async () => {
@@ -203,8 +226,14 @@ describe('multiple audiences types matching behaviour', () => {
     });
 
     describe('logistic regression plus cosine similarity audiences, query matching cosSim only', () => {
-      const cosSimAudience = makeCosSimAudience([1, 1, 1], 'docVector');
-      const logRegAudience = makeLogRegAudience([0, 0, 0], 'docVector'); // doesn't match
+      const cosSimAudience = makeCosSimAudience({
+        vector: matchingVector,
+        queryProperty: 'logRegVector',
+      });
+      const logRegAudience = makeLogRegAudience({
+        vector: notMatchingVector,
+        queryProperty: 'logRegVector',
+      });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
 
       it('adds page view and does match cosine similarity audience', async () => {
@@ -232,8 +261,14 @@ describe('multiple audiences types matching behaviour', () => {
     });
 
     describe('logistic regression plus cosine similarity audiences, query matching logReg only', () => {
-      const cosSimAudience = makeCosSimAudience([0, 0, 0], 'docVector'); // doesn't match
-      const logRegAudience = makeLogRegAudience([1, 1, 1], 'docVector');
+      const cosSimAudience = makeCosSimAudience({
+        vector: notMatchingVector,
+        queryProperty: 'logRegVector',
+      }); // doesn't match
+      const logRegAudience = makeLogRegAudience({
+        vector: matchingVector,
+        queryProperty: 'logRegVector',
+      });
       const audienceDefinitions = [cosSimAudience, logRegAudience];
 
       it('adds page view and does match logistic regression audience', async () => {

--- a/test/unit/audience/versionBump.test.ts
+++ b/test/unit/audience/versionBump.test.ts
@@ -10,13 +10,13 @@ import {
 } from '../../helpers/audienceDefinitions';
 
 describe('edkt behaviour on audience version bump', () => {
-  const matchingVector = [1, 1, 1];
-  const notMatchingVector = [0, 0, 0];
+  const MATCHING_VECTOR = [1, 1, 1];
+  const NOT_MATCHING_VECTOR = [0, 0, 0];
 
   const pageFeatures = {
     docVector: {
       version: 1,
-      value: matchingVector,
+      value: MATCHING_VECTOR,
     },
   };
 
@@ -32,7 +32,7 @@ describe('edkt behaviour on audience version bump', () => {
             makeLogisticRegressionQuery({
               queryValue: {
                 threshold: 0.9,
-                vector: matchingVector,
+                vector: MATCHING_VECTOR,
                 bias: 0,
               },
             }),
@@ -65,7 +65,7 @@ describe('edkt behaviour on audience version bump', () => {
             makeLogisticRegressionQuery({
               queryValue: {
                 threshold: 0.9,
-                vector: notMatchingVector,
+                vector: NOT_MATCHING_VECTOR,
                 bias: 0,
               },
             }),
@@ -96,7 +96,7 @@ describe('edkt behaviour on audience version bump', () => {
             makeLogisticRegressionQuery({
               queryValue: {
                 threshold: 0.9,
-                vector: matchingVector,
+                vector: MATCHING_VECTOR,
                 bias: 0,
               },
             }),
@@ -112,7 +112,7 @@ describe('edkt behaviour on audience version bump', () => {
             makeLogisticRegressionQuery({
               queryValue: {
                 threshold: 0.9,
-                vector: matchingVector,
+                vector: MATCHING_VECTOR,
                 bias: 0,
               },
             }),

--- a/test/unit/audience/versionBump.test.ts
+++ b/test/unit/audience/versionBump.test.ts
@@ -11,6 +11,7 @@ import {
 
 describe('edkt behaviour on audience version bump', () => {
   const matchingVector = [1, 1, 1];
+  const notMatchingVector = [0, 0, 0];
 
   const pageFeatures = {
     docVector: {
@@ -56,7 +57,6 @@ describe('edkt behaviour on audience version bump', () => {
     });
 
     it('should unmatch matchedAudience on audienceDefinition version bump', async () => {
-      const notMatchingVector = [0, 0, 0];
       const audienceDefinitions = [
         makeAudienceDefinition({
           version: 2,

--- a/test/unit/engine/cosineSimilarityCondition.test.ts
+++ b/test/unit/engine/cosineSimilarityCondition.test.ts
@@ -6,19 +6,24 @@ import {
 import { makeCosineSimilarityQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for cosine similarity condition', () => {
+  const matchingVector = [1, 1, 1];
+  const notMatchingVector = [0, 0, 0];
+
   describe('cosine similarity condition with same condition/pageView version', () => {
-    const cosineSimilarityCondition = makeEngineCondition([
-      makeCosineSimilarityQuery({
-        queryValue: {
-          vector: [0.4, 0.8, 0.3],
-          threshold: 0.99,
-        },
-        featureVersion: 1,
-      }),
-    ]);
+    const cosineSimilarityCondition = makeEngineCondition({
+      queries: [
+        makeCosineSimilarityQuery({
+          queryValue: {
+            vector: matchingVector,
+            threshold: 0.99,
+          },
+          featureVersion: 1,
+        }),
+      ],
+    });
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const pageViews = [makePageView([0.4, 0.8, 0.3], 1)];
+      const pageViews = [makePageView({ value: matchingVector, version: 1 })];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
@@ -27,8 +32,12 @@ describe('engine matching behaviour for cosine similarity condition', () => {
 
     it('does not match the page view if similarity is not above threshold', () => {
       const pageViews = [
-        makePageView([0.2, 0.8, 0.1], 1, 100),
-        makePageView([0.3, 0.8, 0.1], 1, 101),
+        makePageView({
+          value: notMatchingVector,
+          version: 1,
+          ts: 100,
+        }),
+        makePageView({ value: notMatchingVector, version: 1, ts: 101 }),
       ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
@@ -39,18 +48,22 @@ describe('engine matching behaviour for cosine similarity condition', () => {
 
   describe('cosine similarity condition with a bumped featureVersion', () => {
     // Vector condition with a bumped featureVersion
-    const cosineSimilarityCondition = makeEngineCondition([
-      makeCosineSimilarityQuery({
-        queryValue: {
-          vector: [0.4, 0.8, 0.3],
-          threshold: 0.99,
-        },
-        featureVersion: 2,
-      }),
-    ]);
+    const cosineSimilarityCondition = makeEngineCondition({
+      queries: [
+        makeCosineSimilarityQuery({
+          queryValue: {
+            vector: matchingVector,
+            threshold: 0.99,
+          },
+          featureVersion: 2,
+        }),
+      ],
+    });
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
-      const pageViews = [makePageView([0.4, 0.8, 0.3], 2, 100)];
+      const pageViews = [
+        makePageView({ value: matchingVector, version: 2, ts: 100 }),
+      ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
@@ -58,7 +71,9 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     });
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
-      const pageViews = [makePageView([0.4, 0.8, 0.3], 1, 100)];
+      const pageViews = [
+        makePageView({ value: matchingVector, version: 1, ts: 100 }),
+      ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 

--- a/test/unit/engine/cosineSimilarityCondition.test.ts
+++ b/test/unit/engine/cosineSimilarityCondition.test.ts
@@ -6,15 +6,15 @@ import {
 import { makeCosineSimilarityQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for cosine similarity condition', () => {
-  const matchingVector = [1, 1, 1];
-  const notMatchingVector = [0, 0, 0];
+  const MATCHING_VECTOR = [1, 1, 1];
+  const NOT_MATCHING_VECTOR = [0, 0, 0];
 
   describe('cosine similarity condition with same condition/pageView version', () => {
     const cosineSimilarityCondition = makeEngineCondition({
       queries: [
         makeCosineSimilarityQuery({
           queryValue: {
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
             threshold: 0.99,
           },
           featureVersion: 1,
@@ -23,7 +23,13 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     });
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const pageViews = [makePageView({ value: matchingVector, version: 1 })];
+      const pageViews = [
+        makePageView({
+          value: MATCHING_VECTOR,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
+      ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
 
@@ -33,11 +39,17 @@ describe('engine matching behaviour for cosine similarity condition', () => {
     it('does not match the page view if similarity is not above threshold', () => {
       const pageViews = [
         makePageView({
-          value: notMatchingVector,
+          value: NOT_MATCHING_VECTOR,
           version: 1,
           ts: 100,
+          queryProperty: 'docVector',
         }),
-        makePageView({ value: notMatchingVector, version: 1, ts: 101 }),
+        makePageView({
+          value: NOT_MATCHING_VECTOR,
+          version: 1,
+          ts: 101,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
@@ -52,7 +64,7 @@ describe('engine matching behaviour for cosine similarity condition', () => {
       queries: [
         makeCosineSimilarityQuery({
           queryValue: {
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
             threshold: 0.99,
           },
           featureVersion: 2,
@@ -62,7 +74,12 @@ describe('engine matching behaviour for cosine similarity condition', () => {
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
       const pageViews = [
-        makePageView({ value: matchingVector, version: 2, ts: 100 }),
+        makePageView({
+          value: MATCHING_VECTOR,
+          version: 2,
+          ts: 100,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);
@@ -72,7 +89,12 @@ describe('engine matching behaviour for cosine similarity condition', () => {
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
       const pageViews = [
-        makePageView({ value: matchingVector, version: 1, ts: 100 }),
+        makePageView({
+          value: MATCHING_VECTOR,
+          version: 1,
+          ts: 100,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(cosineSimilarityCondition, pageViews);

--- a/test/unit/engine/logisticRegressionCondition.test.ts
+++ b/test/unit/engine/logisticRegressionCondition.test.ts
@@ -6,20 +6,25 @@ import {
 import { makeLogisticRegressionQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for logistic regression condition', () => {
+  const matchingVector = [1, 1, 1];
+  const notMatchingVector = [0, 0, 0];
+
   describe('logReg condition with same condition/pageView version', () => {
-    const versionOneCondition = makeEngineCondition([
-      makeLogisticRegressionQuery({
-        queryValue: {
-          vector: [1, 1, 1],
-          threshold: 0.9,
-          bias: 0,
-        },
-        featureVersion: 1,
-      }),
-    ]);
+    const versionOneCondition = makeEngineCondition({
+      queries: [
+        makeLogisticRegressionQuery({
+          queryValue: {
+            vector: matchingVector,
+            threshold: 0.9,
+            bias: 0,
+          },
+          featureVersion: 1,
+        }),
+      ],
+    });
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const pageViews = [makePageView([1, 1, 1], 1)];
+      const pageViews = [makePageView({ value: matchingVector, version: 1 })];
 
       const result = evaluateCondition(versionOneCondition, pageViews);
 
@@ -28,8 +33,8 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
     it('does not match the page view if similarity is not above threshold', () => {
       const pageViews = [
-        makePageView([0.2, 0.8, 0.1], 1, 100),
-        makePageView([0.3, 0.8, 0.1], 1, 101),
+        makePageView({ value: notMatchingVector, version: 1, ts: 100 }),
+        makePageView({ value: notMatchingVector, version: 1, ts: 101 }),
       ];
 
       const result = evaluateCondition(versionOneCondition, pageViews);
@@ -40,19 +45,23 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
   describe('logRef condition with a bumped featureVersion', () => {
     // Vector condition with a bumped featureVersion
-    const versionTwoCondition = makeEngineCondition([
-      makeLogisticRegressionQuery({
-        queryValue: {
-          vector: [1, 1, 1],
-          threshold: 0.9,
-          bias: 0,
-        },
-        featureVersion: 2,
-      }),
-    ]);
+    const versionTwoCondition = makeEngineCondition({
+      queries: [
+        makeLogisticRegressionQuery({
+          queryValue: {
+            vector: matchingVector,
+            threshold: 0.9,
+            bias: 0,
+          },
+          featureVersion: 2,
+        }),
+      ],
+    });
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
-      const pageViews = [makePageView([1, 1, 1], 2, 100)];
+      const pageViews = [
+        makePageView({ value: matchingVector, version: 2, ts: 100 }),
+      ];
 
       const result = evaluateCondition(versionTwoCondition, pageViews);
 
@@ -60,7 +69,9 @@ describe('engine matching behaviour for logistic regression condition', () => {
     });
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
-      const pageViews = [makePageView([0.4, 0.8, 0.3], 1, 100)];
+      const pageViews = [
+        makePageView({ value: matchingVector, version: 1, ts: 100 }),
+      ];
 
       const result = evaluateCondition(versionTwoCondition, pageViews);
 

--- a/test/unit/engine/logisticRegressionCondition.test.ts
+++ b/test/unit/engine/logisticRegressionCondition.test.ts
@@ -24,7 +24,13 @@ describe('engine matching behaviour for logistic regression condition', () => {
     });
 
     it('does match the page view if vector similarity is above threshold', () => {
-      const pageViews = [makePageView({ value: matchingVector, version: 1 })];
+      const pageViews = [
+        makePageView({
+          value: matchingVector,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
+      ];
 
       const result = evaluateCondition(versionOneCondition, pageViews);
 
@@ -33,8 +39,18 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
     it('does not match the page view if similarity is not above threshold', () => {
       const pageViews = [
-        makePageView({ value: notMatchingVector, version: 1, ts: 100 }),
-        makePageView({ value: notMatchingVector, version: 1, ts: 101 }),
+        makePageView({
+          value: notMatchingVector,
+          version: 1,
+          ts: 100,
+          queryProperty: 'docVector',
+        }),
+        makePageView({
+          value: notMatchingVector,
+          version: 1,
+          ts: 101,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(versionOneCondition, pageViews);
@@ -60,7 +76,12 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
     it('does match the page view if similarity is above threshold and has the same featureVersion', () => {
       const pageViews = [
-        makePageView({ value: matchingVector, version: 2, ts: 100 }),
+        makePageView({
+          value: matchingVector,
+          version: 2,
+          ts: 100,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(versionTwoCondition, pageViews);
@@ -70,7 +91,12 @@ describe('engine matching behaviour for logistic regression condition', () => {
 
     it('does not match the page view if similarity is above threshold but does not have the same featureVersion', () => {
       const pageViews = [
-        makePageView({ value: matchingVector, version: 1, ts: 100 }),
+        makePageView({
+          value: matchingVector,
+          version: 1,
+          ts: 100,
+          queryProperty: 'docVector',
+        }),
       ];
 
       const result = evaluateCondition(versionTwoCondition, pageViews);

--- a/test/unit/engine/multipleQueriesCondition.test.ts
+++ b/test/unit/engine/multipleQueriesCondition.test.ts
@@ -6,32 +6,37 @@ import {
 import { makeCosineSimilarityQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for multiple engine condition values', () => {
-  const vectorOne = [0, 1, 0];
-  const vectorTwo = [1, 0, 0];
-  const notMatchingVector = [0, 0, 1];
+  const VECTOR_ONE = [0, 1, 0];
+  const VECTOR_TWO = [1, 0, 0];
+  const NOT_MATCHING_VECTOR = [0, 0, 1];
 
   const multipleNonOverlapingQueriesCondition = makeEngineCondition({
     queries: [
       makeCosineSimilarityQuery({
         queryValue: {
-          vector: vectorOne,
+          vector: VECTOR_ONE,
           threshold: 0.99,
         },
         featureVersion: 1,
       }),
       makeCosineSimilarityQuery({
         queryValue: {
-          vector: vectorTwo,
+          vector: VECTOR_TWO,
           threshold: 0.99,
         },
         featureVersion: 1,
       }),
     ],
-    occurences: 1,
   });
 
   it('does match for condition above threshold on fisrt query object', () => {
-    const pageViews = [makePageView({ value: vectorOne, version: 1 })];
+    const pageViews = [
+      makePageView({
+        value: VECTOR_ONE,
+        version: 1,
+        queryProperty: 'docVector',
+      }),
+    ];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -42,7 +47,13 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   });
 
   it('does match for condition above threshold on second query object', () => {
-    const pageViews = [makePageView({ value: vectorTwo, version: 1 })];
+    const pageViews = [
+      makePageView({
+        value: VECTOR_TWO,
+        version: 1,
+        queryProperty: 'docVector',
+      }),
+    ];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -53,7 +64,13 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   });
 
   it('does not match for condition below threshold on every query object', () => {
-    const pageViews = [makePageView({ value: notMatchingVector, version: 1 })];
+    const pageViews = [
+      makePageView({
+        value: NOT_MATCHING_VECTOR,
+        version: 1,
+        queryProperty: 'docVector',
+      }),
+    ];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -66,23 +83,51 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   it('does match for condition above threshold on at least one (pageView, condition) pair', () => {
     expect(
       evaluateCondition(multipleNonOverlapingQueriesCondition, [
-        makePageView({ value: vectorOne, version: 1 }),
-        makePageView({ value: notMatchingVector, version: 1 }),
+        makePageView({
+          value: VECTOR_ONE,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
+        makePageView({
+          value: NOT_MATCHING_VECTOR,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
       ])
     ).toEqual(true);
     expect(
       evaluateCondition(multipleNonOverlapingQueriesCondition, [
-        makePageView({ value: vectorTwo, version: 1 }),
-        makePageView({ value: notMatchingVector, version: 1 }),
+        makePageView({
+          value: VECTOR_TWO,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
+        makePageView({
+          value: NOT_MATCHING_VECTOR,
+          version: 1,
+          queryProperty: 'docVector',
+        }),
       ])
     ).toEqual(true);
   });
 
   it('does not match for different (condition, pageView) versions attributes', () => {
     const pageViews = [
-      makePageView({ value: vectorOne, version: 2 }),
-      makePageView({ value: vectorTwo, version: 2 }),
-      makePageView({ value: notMatchingVector, version: 2 }),
+      makePageView({
+        value: VECTOR_ONE,
+        version: 2,
+        queryProperty: 'docVector',
+      }),
+      makePageView({
+        value: VECTOR_TWO,
+        version: 2,
+        queryProperty: 'docVector',
+      }),
+      makePageView({
+        value: NOT_MATCHING_VECTOR,
+        version: 2,
+        queryProperty: 'docVector',
+      }),
     ];
 
     const result = evaluateCondition(
@@ -95,9 +140,21 @@ describe('engine matching behaviour for multiple engine condition values', () =>
 
   it('does match for mixed versions/conditions with enough above threshold pairs', () => {
     const pageViews = [
-      makePageView({ value: vectorOne, version: 1 }),
-      makePageView({ value: vectorTwo, version: 2 }),
-      makePageView({ value: notMatchingVector, version: 2 }),
+      makePageView({
+        value: VECTOR_ONE,
+        version: 1,
+        queryProperty: 'docVector',
+      }),
+      makePageView({
+        value: VECTOR_TWO,
+        version: 2,
+        queryProperty: 'docVector',
+      }),
+      makePageView({
+        value: NOT_MATCHING_VECTOR,
+        version: 2,
+        queryProperty: 'docVector',
+      }),
     ];
 
     const result = evaluateCondition(

--- a/test/unit/engine/multipleQueriesCondition.test.ts
+++ b/test/unit/engine/multipleQueriesCondition.test.ts
@@ -6,28 +6,32 @@ import {
 import { makeCosineSimilarityQuery } from '../../helpers/audienceDefinitions';
 
 describe('engine matching behaviour for multiple engine condition values', () => {
-  const multipleNonOverlapingQueriesCondition = makeEngineCondition(
-    [
+  const vectorOne = [0, 1, 0];
+  const vectorTwo = [1, 0, 0];
+  const notMatchingVector = [0, 0, 1];
+
+  const multipleNonOverlapingQueriesCondition = makeEngineCondition({
+    queries: [
       makeCosineSimilarityQuery({
         queryValue: {
-          vector: [0, 1, 0],
+          vector: vectorOne,
           threshold: 0.99,
         },
         featureVersion: 1,
       }),
       makeCosineSimilarityQuery({
         queryValue: {
-          vector: [1, 0, 0],
+          vector: vectorTwo,
           threshold: 0.99,
         },
         featureVersion: 1,
       }),
     ],
-    1
-  );
+    occurences: 1,
+  });
 
   it('does match for condition above threshold on fisrt query object', () => {
-    const pageViews = [makePageView([1, 0, 0], 1)];
+    const pageViews = [makePageView({ value: vectorOne, version: 1 })];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -38,7 +42,7 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   });
 
   it('does match for condition above threshold on second query object', () => {
-    const pageViews = [makePageView([0, 1, 0], 1)];
+    const pageViews = [makePageView({ value: vectorTwo, version: 1 })];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -49,7 +53,7 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   });
 
   it('does not match for condition below threshold on every query object', () => {
-    const pageViews = [makePageView([0, 0, 1], 1)];
+    const pageViews = [makePageView({ value: notMatchingVector, version: 1 })];
 
     const result = evaluateCondition(
       multipleNonOverlapingQueriesCondition,
@@ -62,24 +66,23 @@ describe('engine matching behaviour for multiple engine condition values', () =>
   it('does match for condition above threshold on at least one (pageView, condition) pair', () => {
     expect(
       evaluateCondition(multipleNonOverlapingQueriesCondition, [
-        makePageView([1, 0, 0], 1),
-        makePageView([0, 0, 1], 1),
+        makePageView({ value: vectorOne, version: 1 }),
+        makePageView({ value: notMatchingVector, version: 1 }),
       ])
     ).toEqual(true);
     expect(
       evaluateCondition(multipleNonOverlapingQueriesCondition, [
-        makePageView([0, 1, 0], 1),
-        makePageView([0, 0, 1], 1),
+        makePageView({ value: vectorTwo, version: 1 }),
+        makePageView({ value: notMatchingVector, version: 1 }),
       ])
     ).toEqual(true);
   });
 
   it('does not match for different (condition, pageView) versions attributes', () => {
     const pageViews = [
-      makePageView([1, 0, 0], 2),
-      makePageView([0, 1, 0], 2),
-      makePageView([0, 0, 1], 2),
-      makePageView([1, 1, 1], 2),
+      makePageView({ value: vectorOne, version: 2 }),
+      makePageView({ value: vectorTwo, version: 2 }),
+      makePageView({ value: notMatchingVector, version: 2 }),
     ];
 
     const result = evaluateCondition(
@@ -90,12 +93,11 @@ describe('engine matching behaviour for multiple engine condition values', () =>
     expect(result).toEqual(false);
   });
 
-  it('does match for mixed versions/conditions with enough evidence', () => {
+  it('does match for mixed versions/conditions with enough above threshold pairs', () => {
     const pageViews = [
-      makePageView([1, 0, 0], 1),
-      makePageView([0, 1, 0], 2),
-      makePageView([0, 0, 1], 2),
-      makePageView([1, 1, 1], 2),
+      makePageView({ value: vectorOne, version: 1 }),
+      makePageView({ value: vectorTwo, version: 2 }),
+      makePageView({ value: notMatchingVector, version: 2 }),
     ];
 
     const result = evaluateCondition(

--- a/test/unit/features/addFeatures.test.ts
+++ b/test/unit/features/addFeatures.test.ts
@@ -2,8 +2,8 @@ import { edkt } from '../../../src';
 import { getPageViews } from '../../helpers/localStorage';
 
 describe('edkt viewStore add behaviour', () => {
-  const vendorIds = [873];
-  const omitGdprConsent = true;
+  const VENDOR_IDS = [873];
+  const OMIT_GDPR_CONSENT = true;
 
   const features = {
     docVector: {
@@ -23,8 +23,8 @@ describe('edkt viewStore add behaviour', () => {
     await edkt.run({
       pageFeatures: { ...features, ...moreFeatures },
       audienceDefinitions: [],
-      omitGdprConsent,
-      vendorIds,
+      omitGdprConsent: OMIT_GDPR_CONSENT,
+      vendorIds: VENDOR_IDS,
     });
 
     const edktPageViews = getPageViews();

--- a/test/unit/features/deleteFeatures.test.ts
+++ b/test/unit/features/deleteFeatures.test.ts
@@ -3,19 +3,21 @@ import { edkt } from '../../../src';
 import { getPageViews } from '../../helpers/localStorage';
 
 describe('edkt viewStore cleaning behaviour', () => {
-  const omitGdprConsent = true;
+  const OMIT_GDPR_CONSENT = true;
+  const VECTOR_ONE = [1, 1, 1];
+  const VECTOR_TWO = [0, 0, 0];
 
   const oldFeatures = {
     docVector: {
       version: 1,
-      value: [1, 1, 1],
+      value: VECTOR_ONE,
     },
   };
 
   const newFeatures = {
     docVector: {
       version: 1,
-      value: [0, 0, 0],
+      value: VECTOR_TWO,
     },
   };
 
@@ -32,7 +34,7 @@ describe('edkt viewStore cleaning behaviour', () => {
       await edkt.run({
         pageFeatures: oldFeatures,
         audienceDefinitions: [],
-        omitGdprConsent,
+        omitGdprConsent: OMIT_GDPR_CONSENT,
       });
     }
 
@@ -44,7 +46,7 @@ describe('edkt viewStore cleaning behaviour', () => {
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
-      omitGdprConsent,
+      omitGdprConsent: OMIT_GDPR_CONSENT,
     });
 
     expect(getPageViews()).toHaveLength(9);
@@ -53,7 +55,7 @@ describe('edkt viewStore cleaning behaviour', () => {
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
-      omitGdprConsent,
+      omitGdprConsent: OMIT_GDPR_CONSENT,
       featureStorageSize: 3,
     });
 
@@ -81,7 +83,7 @@ describe('edkt viewStore cleaning behaviour', () => {
       await edkt.run({
         pageFeatures: oldFeatures,
         audienceDefinitions: [],
-        omitGdprConsent,
+        omitGdprConsent: OMIT_GDPR_CONSENT,
         featureStorageSize: 5,
       });
     }
@@ -91,7 +93,7 @@ describe('edkt viewStore cleaning behaviour', () => {
     await edkt.run({
       pageFeatures: newFeatures,
       audienceDefinitions: [],
-      omitGdprConsent,
+      omitGdprConsent: OMIT_GDPR_CONSENT,
       featureStorageSize: 6,
     });
 

--- a/test/unit/run.test.ts
+++ b/test/unit/run.test.ts
@@ -9,6 +9,8 @@ import {
 import { PageView } from '../../types';
 
 describe('edkt run method', () => {
+  const MATCHING_VECTOR = [1, 1, 1];
+
   const makePageViews = (
     timestamp: number,
     pageViewFeatures: PageView['features'],
@@ -22,12 +24,10 @@ describe('edkt run method', () => {
     }));
   };
 
-  const matchingVector = [1, 1, 1];
-
   const pageFeatures = {
     docVector: {
       version: 1,
-      value: matchingVector,
+      value: MATCHING_VECTOR,
     },
   };
 
@@ -38,27 +38,19 @@ describe('edkt run method', () => {
         makeCosineSimilarityQuery({
           queryValue: {
             threshold: 0.99,
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
           },
           queryProperty: 'docVector',
         }),
       ],
     });
 
-    const ONE_SPORTS_PAGE_VIEW = makePageViews(
-      timeStampInSecs(),
-      pageFeatures,
-      1
-    );
+    const ONE_PAGE_VIEW = makePageViews(timeStampInSecs(), pageFeatures, 1);
 
-    const TWO_SPORTS_PAGE_VIEW = makePageViews(
-      timeStampInSecs(),
-      pageFeatures,
-      2
-    );
+    const TWO_PAGE_VIEW = makePageViews(timeStampInSecs(), pageFeatures, 2);
 
     it('does add page view to store', async () => {
-      setUpLocalStorage(ONE_SPORTS_PAGE_VIEW);
+      setUpLocalStorage(ONE_PAGE_VIEW);
 
       await edkt.run({
         pageFeatures,
@@ -70,7 +62,7 @@ describe('edkt run method', () => {
       const latestQueryFeature =
         edktPageViews[edktPageViews.length - 1].features;
 
-      expect(edktPageViews).toHaveLength(ONE_SPORTS_PAGE_VIEW.length + 1);
+      expect(edktPageViews).toHaveLength(ONE_PAGE_VIEW.length + 1);
       expect(latestQueryFeature).toHaveProperty(
         'docVector',
         pageFeatures.docVector
@@ -78,7 +70,7 @@ describe('edkt run method', () => {
     });
 
     it('does not match with sport page view', async () => {
-      setUpLocalStorage(ONE_SPORTS_PAGE_VIEW);
+      setUpLocalStorage(ONE_PAGE_VIEW);
 
       await edkt.run({
         pageFeatures,
@@ -90,7 +82,7 @@ describe('edkt run method', () => {
     });
 
     it('does match with two page view', async () => {
-      setUpLocalStorage(TWO_SPORTS_PAGE_VIEW);
+      setUpLocalStorage(TWO_PAGE_VIEW);
 
       await edkt.run({
         pageFeatures,
@@ -102,7 +94,7 @@ describe('edkt run method', () => {
     });
 
     it('does not match with misconfigured audience filter / page feature', async () => {
-      setUpLocalStorage(TWO_SPORTS_PAGE_VIEW);
+      setUpLocalStorage(TWO_PAGE_VIEW);
 
       const misconfiguredSportAudience = makeAudienceDefinition({
         id: 'sport_id',
@@ -110,7 +102,7 @@ describe('edkt run method', () => {
           makeCosineSimilarityQuery({
             queryValue: {
               threshold: 0.9,
-              vector: matchingVector,
+              vector: MATCHING_VECTOR,
             },
             queryProperty: 'misconfiguredProperty',
           }),
@@ -131,7 +123,7 @@ describe('edkt run method', () => {
     const lookBackPageFeature = {
       docVector: {
         version: 1,
-        value: matchingVector,
+        value: MATCHING_VECTOR,
       },
     };
 
@@ -141,7 +133,7 @@ describe('edkt run method', () => {
       definition: [
         makeCosineSimilarityQuery({
           queryValue: {
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
             threshold: 0.99,
           },
           queryProperty: 'docVector',
@@ -149,7 +141,7 @@ describe('edkt run method', () => {
       ],
     });
 
-    const LOOK_BACK_PAGE_VIEW = makePageViews(
+    const lookBackPageView = makePageViews(
       timeStampInSecs(),
       pageFeatures,
       lookBackAudience.occurrences
@@ -162,14 +154,14 @@ describe('edkt run method', () => {
         makeCosineSimilarityQuery({
           queryValue: {
             threshold: 0.99,
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
           },
           queryProperty: 'docVector',
         }),
       ],
     });
 
-    const LOOK_BACK_INFINITY_PAGE_VIEW = makePageViews(
+    const lookBackInfinityPageView = makePageViews(
       0,
       pageFeatures,
       lookBackInfinityAudience.occurrences
@@ -178,7 +170,7 @@ describe('edkt run method', () => {
     beforeAll(clearStore);
 
     it('does match with lookBack set to 0 with two demo page view at any point in the past', async () => {
-      setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
+      setUpLocalStorage(lookBackInfinityPageView);
 
       await edkt.run({
         pageFeatures: lookBackPageFeature,
@@ -193,7 +185,7 @@ describe('edkt run method', () => {
     });
 
     it('does match with lookBack set to 2 with two blank page view within look back period', async () => {
-      setUpLocalStorage(LOOK_BACK_PAGE_VIEW);
+      setUpLocalStorage(lookBackPageView);
 
       await edkt.run({
         pageFeatures: lookBackPageFeature,
@@ -208,7 +200,7 @@ describe('edkt run method', () => {
     });
 
     it('does not match with lookBack set to 2 with two blank page view outside look back period', async () => {
-      setUpLocalStorage(LOOK_BACK_INFINITY_PAGE_VIEW);
+      setUpLocalStorage(lookBackInfinityPageView);
 
       await edkt.run({
         pageFeatures: lookBackPageFeature,
@@ -228,7 +220,7 @@ describe('edkt run method', () => {
         makeCosineSimilarityQuery({
           queryValue: {
             threshold: 0.99,
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
           },
           queryProperty: 'docVector',
           featureVersion: 2,
@@ -243,7 +235,7 @@ describe('edkt run method', () => {
         makeLogisticRegressionQuery({
           queryValue: {
             threshold: 0.99,
-            vector: matchingVector,
+            vector: MATCHING_VECTOR,
             bias: 0,
           },
           queryProperty: 'docVector',

--- a/test/unit/run.test.ts
+++ b/test/unit/run.test.ts
@@ -1,11 +1,6 @@
 import { edkt } from '../../src';
 import { timeStampInSecs } from '../../src/utils';
-import {
-  clearStore,
-  getPageViews,
-  getMatchedAudiences,
-  setUpLocalStorage,
-} from '../helpers/localStorage';
+import { clearStore, setUpLocalStorage } from '../helpers/localStorage';
 import {
   makeAudienceDefinition,
   makeCosineSimilarityQuery,
@@ -71,7 +66,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      const edktPageViews = getPageViews();
+      const edktPageViews = edkt.getCopyOfPageViews();
       const latestQueryFeature =
         edktPageViews[edktPageViews.length - 1].features;
 
@@ -91,7 +86,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      expect(getMatchedAudiences()).toHaveLength(0);
+      expect(edkt.getMatchedAudiences()).toHaveLength(0);
     });
 
     it('does match with two page view', async () => {
@@ -103,7 +98,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      expect(getMatchedAudiences()).toHaveLength(1);
+      expect(edkt.getMatchedAudiences()).toHaveLength(1);
     });
 
     it('does not match with misconfigured audience filter / page feature', async () => {
@@ -128,7 +123,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      expect(getMatchedAudiences()).toHaveLength(0);
+      expect(edkt.getMatchedAudiences()).toHaveLength(0);
     });
   });
 
@@ -191,7 +186,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      const edktMatchedAudiences = getMatchedAudiences();
+      const edktMatchedAudiences = edkt.getMatchedAudiences();
 
       expect(edktMatchedAudiences).toHaveLength(1);
       expect(edktMatchedAudiences[0].id).toEqual('look_back_infinity_id');
@@ -206,7 +201,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      const edktMatchedAudiences = getMatchedAudiences();
+      const edktMatchedAudiences = edkt.getMatchedAudiences();
 
       expect(edktMatchedAudiences).toHaveLength(1);
       expect(edktMatchedAudiences[0].id).toEqual('look_back_id');
@@ -221,7 +216,7 @@ describe('edkt run method', () => {
         omitGdprConsent: true,
       });
 
-      expect(getMatchedAudiences()).toHaveLength(0);
+      expect(edkt.getMatchedAudiences()).toHaveLength(0);
     });
   });
 
@@ -270,7 +265,7 @@ describe('edkt run method', () => {
       await run();
       await run();
 
-      const edktPageViews = getPageViews();
+      const edktPageViews = edkt.getCopyOfPageViews();
 
       expect(edktPageViews).toEqual([
         {
@@ -282,7 +277,7 @@ describe('edkt run method', () => {
           features: pageFeatures,
         },
       ]);
-      expect(getMatchedAudiences()).toEqual([]);
+      expect(edkt.getMatchedAudiences()).toEqual([]);
     });
   });
 });

--- a/test/unit/store/matchedAudiences.test.ts
+++ b/test/unit/store/matchedAudiences.test.ts
@@ -1,22 +1,18 @@
 import { matchedAudienceStore } from '../../../src/store/matchedAudiences';
 import { storage } from '../../../src/utils';
 import { clearStore } from '../../helpers/localStorage';
-import { MatchedAudience, StorageKeys } from '../../../types';
+import { StorageKeys } from '../../../types';
 
-const createMatchedAudience = (): MatchedAudience => {
-  return {
+describe('matchedAudienceStore', () => {
+  const matchedAudience = {
     id: 'id',
     version: 1,
     matchedAt: 1,
     expiresAt: 2,
     matchedOnCurrentPageView: true,
   };
-};
 
-describe('matchedAudienceStore', () => {
   beforeAll(clearStore);
-
-  const matchedAudience = createMatchedAudience();
 
   it('should load an empty store', () => {
     const matchedAudiences = matchedAudienceStore.getMatchedAudiences();


### PR DESCRIPTION
# Summary

This issue removes unnecessary helpers and abstractions from the edgekit's test suite.
Also, it makes some minor improvements in test code quality and clarity.

Part of https://github.com/AirGrid/rmap/issues/430