### PR TITLE
fix: resolve true in GDPR module

### DIFF
--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -1,7 +1,7 @@
 import { TCData, ConsentStatus } from '../../types';
 import { timeout } from '../utils';
 
-export const waitForTcfApiTimeout = 10 * 1000;
+export const WAIT_FOR_TCF_API = 10 * 1000;
 
 const hasGdprConsent = (vendorIds: number[], tcData: TCData): boolean => {
   const { vendor } = tcData;
@@ -34,11 +34,11 @@ const waitForTcfApi = () => {
           if (!!intervalId) {
             window.clearInterval(intervalId);
           }
-          resolve();
+          resolve(true);
         }
       }, 100);
     }),
-    timeout(waitForTcfApiTimeout, 'TCF API is missing'),
+    timeout(WAIT_FOR_TCF_API, 'TCF API is missing'),
   ]);
 };
 

--- a/test/unit/gdpr.test.ts
+++ b/test/unit/gdpr.test.ts
@@ -1,5 +1,5 @@
 import { edkt } from '../../src';
-import { checkConsentStatus, waitForTcfApiTimeout } from '../../src/gdpr';
+import { checkConsentStatus, WAIT_FOR_TCF_API } from '../../src/gdpr';
 import { TCData } from '../../types';
 import {
   makeAudienceDefinition,
@@ -115,7 +115,7 @@ describe('EdgeKit GDPR tests', () => {
 
   describe('checkForConsent', () => {
     it('should fail to consent if the Transparency and Consent Framework API is missing', async () => {
-      jest.setTimeout(waitForTcfApiTimeout + 500);
+      jest.setTimeout(WAIT_FOR_TCF_API + 500);
       expect(window.__tcfapi).toBeUndefined();
       await expect(checkConsentStatus([airgridVendorId])).rejects.toThrow(
         'TCF API is missing'


### PR DESCRIPTION
closes https://github.com/AirGrid/edgekit/issues/167

The consumer should handle the error thrown when the TCF API is missing.